### PR TITLE
Update Service structs to match API responses

### DIFF
--- a/service.go
+++ b/service.go
@@ -3,7 +3,6 @@ package fastly
 import (
 	"fmt"
 	"sort"
-	"time"
 )
 
 // Service represents a single service for the Fastly account.
@@ -12,10 +11,18 @@ type Service struct {
 	Name          string     `mapstructure:"name"`
 	Comment       string     `mapstructure:"comment"`
 	CustomerID    string     `mapstructure:"customer_id"`
-	ActiveVersion uint       `mapstructure:"active_version"`
-	CreatedAt     *time.Time `mapstructure:"created_at"`
-	UpdatedAt     *time.Time `mapstructure:"updated_at"`
-	DeletedAt     *time.Time `mapstructure:"deleted_at"`
+	ActiveVersion uint       `mapstructure:"version"`
+	Versions      []*Version `mapstructure:"versions"`
+}
+
+type ServiceDetail struct {
+	ID            string     `mapstructure:"id"`
+	Name          string     `mapstructure:"name"`
+	Comment       string     `mapstructure:"comment"`
+	CustomerID    string     `mapstructure:"customer_id"`
+	ActiveVersion Version    `mapstructure:"active_version"`
+	Version       Version    `mapstructure:"version"`
+	Versions      []*Version `mapstructure:"versions"`
 }
 
 // servicesByName is a sortable list of services.
@@ -73,7 +80,7 @@ type GetServiceInput struct {
 
 // GetService retrieves the details for the service with the given id. If no
 // service exists for the given id, the API returns a 400 response (not a 404).
-func (c *Client) GetService(i *GetServiceInput) (*Service, error) {
+func (c *Client) GetService(i *GetServiceInput) (*ServiceDetail, error) {
 	if i.ID == "" {
 		return nil, ErrMissingID
 	}
@@ -84,10 +91,11 @@ func (c *Client) GetService(i *GetServiceInput) (*Service, error) {
 		return nil, err
 	}
 
-	var s *Service
+	var s *ServiceDetail
 	if err := decodeJSON(&s, resp.Body); err != nil {
 		return nil, err
 	}
+
 	return s, nil
 }
 

--- a/version.go
+++ b/version.go
@@ -3,7 +3,6 @@ package fastly
 import (
 	"fmt"
 	"sort"
-	"time"
 )
 
 // Version represents a distinct configuration version.
@@ -16,9 +15,6 @@ type Version struct {
 	Deployed  bool       `mapstructure:"deployed"`
 	Staging   bool       `mapstructure:"staging"`
 	Testing   bool       `mapstructure:"testing"`
-	CreatedAt *time.Time `mapstructure:"created_at"`
-	UpdatedAt *time.Time `mapstructure:"updated_at"`
-	DeletedAt *time.Time `mapstructure:"deleted_at"`
 }
 
 // versionsByNumber is a sortable list of versions. This is used by the version


### PR DESCRIPTION
This PR has a few changes to the `GetService` func and the `Service` and `Version` structs:

* Introduces a new `ServiceDetail` struct as the response from `/service/:id/detail` differs from other service endpoints meaning the `Service` struct cannot be used. Specifically in one the `version` is a number and in the other a version object.
* Changes the `Service` struct tag for the `ActiveVersion` attribute from `active_version` to `version`. The Fastly docs [incorrectly document the field name](https://community.fastly.com/t/documentation-for-get-service-appears-incorrect/594)
* Removes the timestamp attributes from the `Service` struct as the API responses do not include them
* Adds a `Versions` slice to both `Service` and `ServiceDetail` structs listing all versions
* Remove the timestamp attributes from the `Version` struct as they weren't being parsed correctly

Let me know if you want to discuss these in more detail or split them up into separate PRs, thanks :)