### PR TITLE
Return error message on validate failure

### DIFF
--- a/fastly.go
+++ b/fastly.go
@@ -7,6 +7,7 @@ import (
 
 type statusResp struct {
 	Status string
+	Msg    string
 }
 
 func (t *statusResp) Ok() bool {

--- a/version.go
+++ b/version.go
@@ -281,26 +281,30 @@ type ValidateVersionInput struct {
 }
 
 // ValidateVersion validates if the given version is okay.
-func (c *Client) ValidateVersion(i *ValidateVersionInput) (bool, error) {
+func (c *Client) ValidateVersion(i *ValidateVersionInput) (bool, string, error) {
+	var msg string
+
 	if i.Service == "" {
-		return false, ErrMissingService
+		return false, msg, ErrMissingService
 	}
 
 	if i.Version == "" {
-		return false, ErrMissingVersion
+		return false, msg, ErrMissingVersion
 	}
 
 	path := fmt.Sprintf("/service/%s/version/%s/validate", i.Service, i.Version)
-	resp, err := c.Put(path, nil)
+	resp, err := c.Get(path, nil)
 	if err != nil {
-		return false, err
+		return false, msg, err
 	}
 
 	var r *statusResp
 	if err := decodeJSON(&r, resp.Body); err != nil {
-		return false, err
+		return false, msg, err
 	}
-	return r.Ok(), nil
+
+	msg = r.Msg
+	return r.Ok(), msg, nil
 }
 
 // LockVersionInput is the input to the LockVersion function.

--- a/version_test.go
+++ b/version_test.go
@@ -195,14 +195,14 @@ func TestClient_CloneVersion_validation(t *testing.T) {
 
 func TestClient_ValidateVersion_validation(t *testing.T) {
 	var err error
-	_, err = testClient.ValidateVersion(&ValidateVersionInput{
+	_, _, err = testClient.ValidateVersion(&ValidateVersionInput{
 		Service: "",
 	})
 	if err != ErrMissingService {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.ValidateVersion(&ValidateVersionInput{
+	_, _, err = testClient.ValidateVersion(&ValidateVersionInput{
 		Service: "foo",
 		Version: "",
 	})


### PR DESCRIPTION
If the version validate call fails, include the error message from Fastly in the return arguments.