### PR TITLE
Fix `directory` attribute name in FTP structs

### DIFF
--- a/ftp.go
+++ b/ftp.go
@@ -16,7 +16,7 @@ type FTP struct {
 	Port              uint       `mapstructure:"port"`
 	Username          string     `mapstructure:"user"`
 	Password          string     `mapstructure:"password"`
-	Path              string     `mapstructure:"path"`
+	Directory         string     `mapstructure:"directory"`
 	Period            uint       `mapstructure:"period"`
 	GzipLevel         uint8      `mapstructure:"gzip_level"`
 	Format            string     `mapstructure:"format"`
@@ -82,7 +82,7 @@ type CreateFTPInput struct {
 	Port              uint   `form:"port,omitempty"`
 	Username          string `form:"user,omitempty"`
 	Password          string `form:"password,omitempty"`
-	Path              string `form:"path,omitempty"`
+	Directory         string `form:"directory,omitempty"`
 	Period            uint   `form:"period,omitempty"`
 	GzipLevel         uint8  `form:"gzip_level,omitempty"`
 	Format            string `form:"format,omitempty"`
@@ -166,7 +166,7 @@ type UpdateFTPInput struct {
 	Port              uint   `form:"port,omitempty"`
 	Username          string `form:"user,omitempty"`
 	Password          string `form:"password,omitempty"`
-	Path              string `form:"path,omitempty"`
+	Directory         string `form:"directory,omitempty"`
 	Period            uint   `form:"period,omitempty"`
 	GzipLevel         uint8  `form:"gzip_level,omitempty"`
 	Format            string `form:"format,omitempty"`

--- a/ftp_test.go
+++ b/ftp_test.go
@@ -16,7 +16,7 @@ func TestClient_FTPs(t *testing.T) {
 		Port:            1234,
 		Username:        "username",
 		Password:        "password",
-		Path:            "/dir",
+		Directory:       "/dir",
 		Period:          12,
 		GzipLevel:       9,
 		Format:          "format",
@@ -56,8 +56,8 @@ func TestClient_FTPs(t *testing.T) {
 	if ftp.Password != "password" {
 		t.Errorf("bad password: %q", ftp.Password)
 	}
-	if ftp.Path != "/dir" {
-		t.Errorf("bad directory: %q", ftp.Path)
+	if ftp.Directory != "/dir" {
+		t.Errorf("bad directory: %q", ftp.Directory)
 	}
 	if ftp.Period != 12 {
 		t.Errorf("bad period: %q", ftp.Period)
@@ -108,8 +108,8 @@ func TestClient_FTPs(t *testing.T) {
 	if ftp.Password != nftp.Password {
 		t.Errorf("bad password: %q", ftp.Password)
 	}
-	if ftp.Path != nftp.Path {
-		t.Errorf("bad directory: %q", ftp.Path)
+	if ftp.Directory != nftp.Directory {
+		t.Errorf("bad directory: %q", ftp.Directory)
 	}
 	if ftp.Period != nftp.Period {
 		t.Errorf("bad period: %q", ftp.Period)


### PR DESCRIPTION
See https://docs.fastly.com/api/logging#logging_ftp