### PR TITLE
Add ServiceDetails method, modify Service method

### DIFF
--- a/service.go
+++ b/service.go
@@ -78,9 +78,31 @@ type GetServiceInput struct {
 	ID string
 }
 
+// GetService retrieves the service information for the service with the given
+// id. If no service exists for the given id, the API returns a 400 response
+// (not a 404).
+func (c *Client) GetService(i *GetServiceInput) (*Service, error) {
+	if i.ID == "" {
+		return nil, ErrMissingID
+	}
+
+	path := fmt.Sprintf("/service/%s", i.ID)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var s *Service
+	if err := decodeJSON(&s, resp.Body); err != nil {
+		return nil, err
+	}
+
+	return s, nil
+}
+
 // GetService retrieves the details for the service with the given id. If no
 // service exists for the given id, the API returns a 400 response (not a 404).
-func (c *Client) GetService(i *GetServiceInput) (*ServiceDetail, error) {
+func (c *Client) GetServiceDetails(i *GetServiceInput) (*ServiceDetail, error) {
 	if i.ID == "" {
 		return nil, ErrMissingID
 	}

--- a/service_test.go
+++ b/service_test.go
@@ -55,6 +55,24 @@ func TestClient_Services(t *testing.T) {
 		t.Errorf("bad comment: %q (%q)", s.Comment, ns.Comment)
 	}
 
+	// Get Details
+	nsd, err := testClient.GetServiceDetails(&GetServiceInput{
+		ID: s.ID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if s.Name != nsd.Name {
+		t.Errorf("bad name: %q (%q)", s.Name, nsd.Name)
+	}
+	if s.Comment != nsd.Comment {
+		t.Errorf("bad comment: %q (%q)", s.Comment, nsd.Comment)
+	}
+	if nsd.Version.Number == "" {
+		t.Errorf("Service Detail Version is empty: (%#v)", nsd)
+	}
+
 	// Search
 	nb, err := testClient.SearchService(&SearchServiceInput{
 		Name: "test-service",


### PR DESCRIPTION
This PR adds a ServiceDetails method, which hits the `service/id/details`
endpoint, and restores the Service method to hitting `service/id` endpoint.

This undos some of #1 , in that `GetService` once again hits the `service/id` endpoint and returns a `Service` struct, instead of hitting `service/id/details` and returning `ServiceDetail` struct