### PR TITLE
Additions to Service, Domain, and Backend

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -22,6 +22,7 @@ type Backend struct {
 	Weight              uint     `mapstructure:"weight"`
 	RequestCondition    string   `mapstructure:"request_condition"`
 	HealthCheck         string   `mapstructure:"healthcheck"`
+	Hostname            string   `mapstructure:"hostname"`
 	UseSSL              bool     `mapstructure:"use_ssl"`
 	SSLCheckCert        bool     `mapstructure:"ssl_check_cert"`
 	SSLHostname         string   `mapstructure:"ssl_hostname"`

--- a/domain.go
+++ b/domain.go
@@ -33,7 +33,7 @@ type ListDomainsInput struct {
 	Version string
 }
 
-// ListDomains returns the list of domains for this account.
+// ListDomains returns the list of domains for this Service.
 func (c *Client) ListDomains(i *ListDomainsInput) ([]*Domain, error) {
 	if i.Service == "" {
 		return nil, ErrMissingService

--- a/service.go
+++ b/service.go
@@ -11,6 +11,9 @@ type Service struct {
 	Name          string     `mapstructure:"name"`
 	Comment       string     `mapstructure:"comment"`
 	CustomerID    string     `mapstructure:"customer_id"`
+	CreatedAt     string     `mapstructure:"created_at"`
+	UpdatedAt     string     `mapstructure:"updated_at"`
+	DeletedAt     string     `mapstructure:"deleted_at"`
 	ActiveVersion uint       `mapstructure:"version"`
 	Versions      []*Version `mapstructure:"versions"`
 }

--- a/service_test.go
+++ b/service_test.go
@@ -55,6 +55,18 @@ func TestClient_Services(t *testing.T) {
 		t.Errorf("bad comment: %q (%q)", s.Comment, ns.Comment)
 	}
 
+	if ns.CreatedAt == "" {
+		t.Errorf("Bad created at: empty")
+	}
+
+	if ns.UpdatedAt == "" {
+		t.Errorf("Bad updated at: empty")
+	}
+
+	if ns.DeletedAt != "" {
+		t.Errorf("Bad deleted at: %s", ns.DeletedAt)
+	}
+
 	// Get Details
 	nsd, err := testClient.GetServiceDetails(&GetServiceInput{
 		ID: s.ID,


### PR DESCRIPTION
- Service now supports `deleted_at`; added deleted, created, updated at
- Updates documentation on domain; it's for the Service, not account
- Added Hostname to backend; if a hostname is used in address, it will show up
  here. If an IP is used, hostname will be empty

I had difficulty running tests... it seems they are hardcoded to an account? 
I took a spike at refactoring that, but I don't know a way to clean up a service after each test/suite 