### PR TITLE
Gzips: Allow empty ContentTypes, Extensions

### DIFF
--- a/gzip.go
+++ b/gzip.go
@@ -67,8 +67,8 @@ type CreateGzipInput struct {
 	Version string
 
 	Name           string `form:"name,omitempty"`
-	ContentTypes   string `form:"content_types,omitempty"`
-	Extensions     string `form:"extensions,omitempty"`
+	ContentTypes   string `form:"content_types"`
+	Extensions     string `form:"extensions"`
 	CacheCondition string `form:"cache_condition,omitempty"`
 }
 


### PR DESCRIPTION
This PR removes the `omitempty` attribute of `ContentTypes` and `Extensions` for the `Gzip` struct. In developing the Fastly Provider for Terraform, I've found that _not_ submitting a value for either of these will result in that attribute receiving a default configuration:

``` 
# omit content_types
$ curl -s -H "Fastly-Key: ******" -X POST -d "name=thing&extensions=css" https://api.fastly.com/service/60wRp8bq9WXSPwANtoWaFx/version/1/gzip | jq . 
{ 
"name": "thing", 
"extensions": "css", 
"service_id": "60wRp8bq9WXSPwANtoWaFx", 
"version": "1", 
"content_types": "text/html application/x-javascript text/css application/javascript text/javascript application/json application/vnd.ms-fontobject application/x-font-opentype application/x-font-truetype application/x-font-ttf application/xml font/eot font/opentype font/otf image/svg+xml image/vnd.microsoft.icon text/plain text/xml", 
"cache_condition": "" 
}

# omit extensions
$ curl -s -H "Fastly-Key: ******" -X POST -d "name=otherthing&content_types=text/html" https://api.fastly.com/service/60wRp8bq9WXSPwANtoWaFx/version/1/gzip | jq . 
{ 
"name": "otherthing", 
"content_types": "text/html", 
"service_id": "60wRp8bq9WXSPwANtoWaFx", 
"version": "1", 
"cache_condition": "", 
"extensions": "css js html eot ico otf ttf json" 
} 
$ 
```


I opened a support ticket with Fastly and got work that this was intentional, and the solution is to send an empty string... I can share the convo privately if you'd like, but here's the reply:

![fastlysupport](https://cloud.githubusercontent.com/assets/61721/14681595/5b51d6ec-06e7-11e6-9c6b-1ae0ad3ec792.png)

I've added a test to confirm the omissions, but I'm having trouble running the tests. I also fix what I think is a typo in the tests; in the `Get` call we create a new `ngzip` struct to receive the value, but we do the checks against prior `gzip` struct. The gzip fixtures need to be recreated. 