### PR TITLE
Add Domain attribute to S3 logging struct

### DIFF
--- a/s3.go
+++ b/s3.go
@@ -13,6 +13,7 @@ type S3 struct {
 
 	Name              string     `mapstructure:"name"`
 	BucketName        string     `mapstructure:"bucket_name"`
+	Domain            string     `mapstructure:"domain"`
 	AccessKey         string     `mapstructure:"access_key"`
 	SecretKey         string     `mapstructure:"secret_key"`
 	Path              string     `mapstructure:"path"`
@@ -78,6 +79,7 @@ type CreateS3Input struct {
 
 	Name              string `form:"name,omitempty"`
 	BucketName        string `form:"bucket_name,omitempty"`
+	Domain            string `form:"domain,omitempty"`
 	AccessKey         string `form:"access_key,omitempty"`
 	SecretKey         string `form:"secret_key,omitempty"`
 	Path              string `form:"path,omitempty"`
@@ -161,6 +163,7 @@ type UpdateS3Input struct {
 
 	NewName           string `form:"name,omitempty"`
 	BucketName        string `form:"bucket_name,omitempty"`
+	Domain            string `form:"domain,omitempty"`
 	AccessKey         string `form:"access_key,omitempty"`
 	SecretKey         string `form:"secret_key,omitempty"`
 	Path              string `form:"path,omitempty"`

--- a/s3_test.go
+++ b/s3_test.go
@@ -19,6 +19,7 @@ func TestClient_S3s(t *testing.T) {
 			Version:         tv.Number,
 			Name:            "test-s3",
 			BucketName:      "bucket-name",
+			Domain:          "s3-website-us-west-2.amazonaws.com",
 			AccessKey:       "access_key",
 			SecretKey:       "secret_key",
 			Path:            "/path",
@@ -60,6 +61,9 @@ func TestClient_S3s(t *testing.T) {
 	}
 	if s3.SecretKey != "secret_key" {
 		t.Errorf("bad secret_key: %q", s3.SecretKey)
+	}
+	if s3.Domain != "s3-website-us-west-2.amazonaws.com" {
+		t.Errorf("bad Domain: %q", s3.Domain)
 	}
 	if s3.Path != "/path" {
 		t.Errorf("bad path: %q", s3.Path)


### PR DESCRIPTION
It's explained in the user guide, but missing from the API docs:

- Guide: https://docs.fastly.com/guides/streaming-logs/log-streaming-amazon-s3
- API Docs: https://docs.fastly.com/api/logging#logging_s3

I have a support issue opened to confirm. I've confirmed the field exists and is
usable via curl, just waiting to hear if the omission is for a reason or just a
mistake.