### PR TITLE
Use Compatibools for IgnoreIfSet input.

### DIFF
--- a/header.go
+++ b/header.go
@@ -119,7 +119,7 @@ type CreateHeaderInput struct {
 
 	Name              string       `form:"name,omitempty"`
 	Action            HeaderAction `form:"action,omitempty"`
-	IgnoreIfSet       bool         `form:"ignore_if_set,omitempty"`
+	IgnoreIfSet       Compatibool  `form:"ignore_if_set,omitempty"`
 	Type              HeaderType   `form:"type,omitempty"`
 	Destination       string       `form:"dst,omitempty"`
 	Source            string       `form:"src,omitempty"`
@@ -204,7 +204,7 @@ type UpdateHeaderInput struct {
 
 	NewName           string       `form:"name,omitempty"`
 	Action            HeaderAction `form:"action,omitempty"`
-	IgnoreIfSet       bool         `form:"ignore_if_set,omitempty"`
+	IgnoreIfSet       Compatibool  `form:"ignore_if_set,omitempty"`
 	Type              HeaderType   `form:"type,omitempty"`
 	Destination       string       `form:"dst,omitempty"`
 	Source            string       `form:"src,omitempty"`


### PR DESCRIPTION
Right now it is impossible to set this field to true up in Fastly since it is sending up 'true' strings, which fastly will silently translate to '0'. This change fixes that.

Note that if anyone is using this lib is setting this field to `true`, this change will make that actually happen, which may result in unexpected consequences.