### PR TITLE
Close the resp body to prevent socket leaks.

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -67,6 +67,7 @@ func (c *Client) ListBackends(i *ListBackendsInput) ([]*Backend, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var bs []*Backend
 	if err := decodeJSON(&bs, resp.Body); err != nil {
@@ -120,6 +121,7 @@ func (c *Client) CreateBackend(i *CreateBackendInput) (*Backend, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var b *Backend
 	if err := decodeJSON(&b, resp.Body); err != nil {
@@ -158,6 +160,7 @@ func (c *Client) GetBackend(i *GetBackendInput) (*Backend, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var b *Backend
 	if err := decodeJSON(&b, resp.Body); err != nil {
@@ -217,6 +220,7 @@ func (c *Client) UpdateBackend(i *UpdateBackendInput) (*Backend, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var b *Backend
 	if err := decodeJSON(&b, resp.Body); err != nil {
@@ -255,6 +259,7 @@ func (c *Client) DeleteBackend(i *DeleteBackendInput) error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	var r *statusResp
 	if err := decodeJSON(&r, resp.Body); err != nil {

--- a/billing.go
+++ b/billing.go
@@ -72,6 +72,7 @@ func (c *Client) GetBilling(i *GetBillingInput) (*Billing, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var b *Billing
 	if err := decodeJSON(&b, resp.Body); err != nil {

--- a/cache_setting.go
+++ b/cache_setting.go
@@ -66,6 +66,7 @@ func (c *Client) ListCacheSettings(i *ListCacheSettingsInput) ([]*CacheSetting, 
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var cs []*CacheSetting
 	if err := decodeJSON(&cs, resp.Body); err != nil {
@@ -104,6 +105,7 @@ func (c *Client) CreateCacheSetting(i *CreateCacheSettingInput) (*CacheSetting, 
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var cs *CacheSetting
 	if err := decodeJSON(&cs, resp.Body); err != nil {
@@ -143,6 +145,7 @@ func (c *Client) GetCacheSetting(i *GetCacheSettingInput) (*CacheSetting, error)
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var cs *CacheSetting
 	if err := decodeJSON(&cs, resp.Body); err != nil {
@@ -187,6 +190,7 @@ func (c *Client) UpdateCacheSetting(i *UpdateCacheSettingInput) (*CacheSetting, 
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var cs *CacheSetting
 	if err := decodeJSON(&cs, resp.Body); err != nil {
@@ -225,6 +229,7 @@ func (c *Client) DeleteCacheSetting(i *DeleteCacheSettingInput) error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	var r *statusResp
 	if err := decodeJSON(&r, resp.Body); err != nil {

--- a/condition.go
+++ b/condition.go
@@ -50,6 +50,7 @@ func (c *Client) ListConditions(i *ListConditionsInput) ([]*Condition, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var cs []*Condition
 	if err := decodeJSON(&cs, resp.Body); err != nil {
@@ -87,6 +88,7 @@ func (c *Client) CreateCondition(i *CreateConditionInput) (*Condition, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var co *Condition
 	if err := decodeJSON(&co, resp.Body); err != nil {
@@ -125,6 +127,7 @@ func (c *Client) GetCondition(i *GetConditionInput) (*Condition, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var co *Condition
 	if err := decodeJSON(&co, resp.Body); err != nil {
@@ -167,6 +170,7 @@ func (c *Client) UpdateCondition(i *UpdateConditionInput) (*Condition, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var co *Condition
 	if err := decodeJSON(&co, resp.Body); err != nil {
@@ -205,6 +209,7 @@ func (c *Client) DeleteCondition(i *DeleteConditionInput) error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	var r *statusResp
 	if err := decodeJSON(&r, resp.Body); err != nil {

--- a/content.go
+++ b/content.go
@@ -40,6 +40,7 @@ func (c *Client) EdgeCheck(i *EdgeCheckInput) ([]*EdgeCheck, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var e []*EdgeCheck
 	if err := decodeJSON(&e, resp.Body); err != nil {

--- a/dictionary.go
+++ b/dictionary.go
@@ -49,6 +49,7 @@ func (c *Client) ListDictionaries(i *ListDictionariesInput) ([]*Dictionary, erro
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var bs []*Dictionary
 	if err := decodeJSON(&bs, resp.Body); err != nil {
@@ -83,6 +84,7 @@ func (c *Client) CreateDictionary(i *CreateDictionaryInput) (*Dictionary, error)
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var b *Dictionary
 	if err := decodeJSON(&b, resp.Body); err != nil {
@@ -121,6 +123,7 @@ func (c *Client) GetDictionary(i *GetDictionaryInput) (*Dictionary, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var b *Dictionary
 	if err := decodeJSON(&b, resp.Body); err != nil {
@@ -161,6 +164,7 @@ func (c *Client) UpdateDictionary(i *UpdateDictionaryInput) (*Dictionary, error)
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var b *Dictionary
 	if err := decodeJSON(&b, resp.Body); err != nil {

--- a/dictionary_item.go
+++ b/dictionary_item.go
@@ -49,6 +49,7 @@ func (c *Client) ListDictionaryItems(i *ListDictionaryItemsInput) ([]*Dictionary
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var bs []*DictionaryItem
 	if err := decodeJSON(&bs, resp.Body); err != nil {
@@ -84,6 +85,7 @@ func (c *Client) CreateDictionaryItem(i *CreateDictionaryItemInput) (*Dictionary
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var b *DictionaryItem
 	if err := decodeJSON(&b, resp.Body); err != nil {
@@ -122,6 +124,7 @@ func (c *Client) GetDictionaryItem(i *GetDictionaryItemInput) (*DictionaryItem, 
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var b *DictionaryItem
 	if err := decodeJSON(&b, resp.Body); err != nil {
@@ -162,6 +165,7 @@ func (c *Client) UpdateDictionaryItem(i *UpdateDictionaryItemInput) (*Dictionary
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var b *DictionaryItem
 	if err := decodeJSON(&b, resp.Body); err != nil {

--- a/diff.go
+++ b/diff.go
@@ -48,6 +48,7 @@ func (c *Client) GetDiff(i *GetDiffInput) (*Diff, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var d *Diff
 	if err := decodeJSON(&d, resp.Body); err != nil {

--- a/director.go
+++ b/director.go
@@ -69,6 +69,7 @@ func (c *Client) ListDirectors(i *ListDirectorsInput) ([]*Director, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var ds []*Director
 	if err := decodeJSON(&ds, resp.Body); err != nil {
@@ -107,6 +108,7 @@ func (c *Client) CreateDirector(i *CreateDirectorInput) (*Director, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var d *Director
 	if err := decodeJSON(&d, resp.Body); err != nil {
@@ -145,6 +147,7 @@ func (c *Client) GetDirector(i *GetDirectorInput) (*Director, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var d *Director
 	if err := decodeJSON(&d, resp.Body); err != nil {
@@ -188,6 +191,7 @@ func (c *Client) UpdateDirector(i *UpdateDirectorInput) (*Director, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var d *Director
 	if err := decodeJSON(&d, resp.Body); err != nil {
@@ -226,6 +230,7 @@ func (c *Client) DeleteDirector(i *DeleteDirectorInput) error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	var r *statusResp
 	if err := decodeJSON(&r, resp.Body); err != nil {

--- a/director_backend.go
+++ b/director_backend.go
@@ -57,6 +57,7 @@ func (c *Client) CreateDirectorBackend(i *CreateDirectorBackendInput) (*Director
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var b *DirectorBackend
 	if err := decodeJSON(&b, resp.Body); err != nil {
@@ -103,6 +104,7 @@ func (c *Client) GetDirectorBackend(i *GetDirectorBackendInput) (*DirectorBacken
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var b *DirectorBackend
 	if err := decodeJSON(&b, resp.Body); err != nil {
@@ -149,6 +151,7 @@ func (c *Client) DeleteDirectorBackend(i *DeleteDirectorBackendInput) error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	var r *statusResp
 	if err := decodeJSON(&r, resp.Body); err != nil {

--- a/domain.go
+++ b/domain.go
@@ -48,6 +48,7 @@ func (c *Client) ListDomains(i *ListDomainsInput) ([]*Domain, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var ds []*Domain
 	if err := decodeJSON(&ds, resp.Body); err != nil {
@@ -86,6 +87,7 @@ func (c *Client) CreateDomain(i *CreateDomainInput) (*Domain, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var d *Domain
 	if err := decodeJSON(&d, resp.Body); err != nil {
@@ -124,6 +126,7 @@ func (c *Client) GetDomain(i *GetDomainInput) (*Domain, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var d *Domain
 	if err := decodeJSON(&d, resp.Body); err != nil {
@@ -169,6 +172,7 @@ func (c *Client) UpdateDomain(i *UpdateDomainInput) (*Domain, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var d *Domain
 	if err := decodeJSON(&d, resp.Body); err != nil {

--- a/ftp.go
+++ b/ftp.go
@@ -61,6 +61,7 @@ func (c *Client) ListFTPs(i *ListFTPsInput) ([]*FTP, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var ftps []*FTP
 	if err := decodeJSON(&ftps, resp.Body); err != nil {
@@ -105,6 +106,7 @@ func (c *Client) CreateFTP(i *CreateFTPInput) (*FTP, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var ftp *FTP
 	if err := decodeJSON(&ftp, resp.Body); err != nil {
@@ -143,6 +145,7 @@ func (c *Client) GetFTP(i *GetFTPInput) (*FTP, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var b *FTP
 	if err := decodeJSON(&b, resp.Body); err != nil {
@@ -193,6 +196,7 @@ func (c *Client) UpdateFTP(i *UpdateFTPInput) (*FTP, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var b *FTP
 	if err := decodeJSON(&b, resp.Body); err != nil {
@@ -231,6 +235,7 @@ func (c *Client) DeleteFTP(i *DeleteFTPInput) error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	var r *statusResp
 	if err := decodeJSON(&r, resp.Body); err != nil {

--- a/gcs.go
+++ b/gcs.go
@@ -56,6 +56,7 @@ func (c *Client) ListGCSs(i *ListGCSsInput) ([]*GCS, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var gcses []*GCS
 	if err := decodeJSON(&gcses, resp.Body); err != nil {
@@ -99,6 +100,7 @@ func (c *Client) CreateGCS(i *CreateGCSInput) (*GCS, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var gcs *GCS
 	if err := decodeJSON(&gcs, resp.Body); err != nil {
@@ -137,6 +139,7 @@ func (c *Client) GetGCS(i *GetGCSInput) (*GCS, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var b *GCS
 	if err := decodeJSON(&b, resp.Body); err != nil {
@@ -186,6 +189,7 @@ func (c *Client) UpdateGCS(i *UpdateGCSInput) (*GCS, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var b *GCS
 	if err := decodeJSON(&b, resp.Body); err != nil {
@@ -224,6 +228,7 @@ func (c *Client) DeleteGCS(i *DeleteGCSInput) error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	var r *statusResp
 	if err := decodeJSON(&r, resp.Body); err != nil {

--- a/gzip.go
+++ b/gzip.go
@@ -50,6 +50,7 @@ func (c *Client) ListGzips(i *ListGzipsInput) ([]*Gzip, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var gzips []*Gzip
 	if err := decodeJSON(&gzips, resp.Body); err != nil {
@@ -87,6 +88,7 @@ func (c *Client) CreateGzip(i *CreateGzipInput) (*Gzip, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var gzip *Gzip
 	if err := decodeJSON(&gzip, resp.Body); err != nil {
@@ -125,6 +127,7 @@ func (c *Client) GetGzip(i *GetGzipInput) (*Gzip, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var b *Gzip
 	if err := decodeJSON(&b, resp.Body); err != nil {
@@ -168,6 +171,7 @@ func (c *Client) UpdateGzip(i *UpdateGzipInput) (*Gzip, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var b *Gzip
 	if err := decodeJSON(&b, resp.Body); err != nil {
@@ -206,6 +210,7 @@ func (c *Client) DeleteGzip(i *DeleteGzipInput) error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	var r *statusResp
 	if err := decodeJSON(&r, resp.Body); err != nil {

--- a/header.go
+++ b/header.go
@@ -101,6 +101,7 @@ func (c *Client) ListHeaders(i *ListHeadersInput) ([]*Header, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var bs []*Header
 	if err := decodeJSON(&bs, resp.Body); err != nil {
@@ -146,6 +147,7 @@ func (c *Client) CreateHeader(i *CreateHeaderInput) (*Header, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var b *Header
 	if err := decodeJSON(&b, resp.Body); err != nil {
@@ -184,6 +186,7 @@ func (c *Client) GetHeader(i *GetHeaderInput) (*Header, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var b *Header
 	if err := decodeJSON(&b, resp.Body); err != nil {
@@ -235,6 +238,7 @@ func (c *Client) UpdateHeader(i *UpdateHeaderInput) (*Header, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var b *Header
 	if err := decodeJSON(&b, resp.Body); err != nil {
@@ -273,6 +277,7 @@ func (c *Client) DeleteHeader(i *DeleteHeaderInput) error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	var r *statusResp
 	if err := decodeJSON(&r, resp.Body); err != nil {

--- a/health_check.go
+++ b/health_check.go
@@ -58,6 +58,7 @@ func (c *Client) ListHealthChecks(i *ListHealthChecksInput) ([]*HealthCheck, err
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var hcs []*HealthCheck
 	if err := decodeJSON(&hcs, resp.Body); err != nil {
@@ -102,6 +103,7 @@ func (c *Client) CreateHealthCheck(i *CreateHealthCheckInput) (*HealthCheck, err
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var h *HealthCheck
 	if err := decodeJSON(&h, resp.Body); err != nil {
@@ -140,6 +142,7 @@ func (c *Client) GetHealthCheck(i *GetHealthCheckInput) (*HealthCheck, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var h *HealthCheck
 	if err := decodeJSON(&h, resp.Body); err != nil {
@@ -190,6 +193,7 @@ func (c *Client) UpdateHealthCheck(i *UpdateHealthCheckInput) (*HealthCheck, err
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var h *HealthCheck
 	if err := decodeJSON(&h, resp.Body); err != nil {
@@ -228,6 +232,7 @@ func (c *Client) DeleteHealthCheck(i *DeleteHealthCheckInput) error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	var r *statusResp
 	if err := decodeJSON(&r, resp.Body); err != nil {

--- a/ip.go
+++ b/ip.go
@@ -9,6 +9,7 @@ func (c *Client) IPs() (IPAddrs, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var m map[string][]string
 	if err := decodeJSON(&m, resp.Body); err != nil {

--- a/logentries.go
+++ b/logentries.go
@@ -56,6 +56,7 @@ func (c *Client) ListLogentries(i *ListLogentriesInput) ([]*Logentries, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var ls []*Logentries
 	if err := decodeJSON(&ls, resp.Body); err != nil {
@@ -95,6 +96,7 @@ func (c *Client) CreateLogentries(i *CreateLogentriesInput) (*Logentries, error)
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var l *Logentries
 	if err := decodeJSON(&l, resp.Body); err != nil {
@@ -133,6 +135,7 @@ func (c *Client) GetLogentries(i *GetLogentriesInput) (*Logentries, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var l *Logentries
 	if err := decodeJSON(&l, resp.Body); err != nil {
@@ -178,6 +181,7 @@ func (c *Client) UpdateLogentries(i *UpdateLogentriesInput) (*Logentries, error)
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var l *Logentries
 	if err := decodeJSON(&l, resp.Body); err != nil {
@@ -216,6 +220,7 @@ func (c *Client) DeleteLogentries(i *DeleteLogentriesInput) error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	var r *statusResp
 	if err := decodeJSON(&r, resp.Body); err != nil {

--- a/papertrail.go
+++ b/papertrail.go
@@ -55,6 +55,7 @@ func (c *Client) ListPapertrails(i *ListPapertrailsInput) ([]*Papertrail, error)
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var ps []*Papertrail
 	if err := decodeJSON(&ps, resp.Body); err != nil {
@@ -96,6 +97,7 @@ func (c *Client) CreatePapertrail(i *CreatePapertrailInput) (*Papertrail, error)
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var p *Papertrail
 	if err := decodeJSON(&p, resp.Body); err != nil {
@@ -134,6 +136,7 @@ func (c *Client) GetPapertrail(i *GetPapertrailInput) (*Papertrail, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var p *Papertrail
 	if err := decodeJSON(&p, resp.Body); err != nil {
@@ -181,6 +184,7 @@ func (c *Client) UpdatePapertrail(i *UpdatePapertrailInput) (*Papertrail, error)
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var p *Papertrail
 	if err := decodeJSON(&p, resp.Body); err != nil {
@@ -219,6 +223,7 @@ func (c *Client) DeletePapertrail(i *DeletePapertrailInput) error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	var r *statusResp
 	if err := decodeJSON(&r, resp.Body); err != nil {

--- a/purge.go
+++ b/purge.go
@@ -39,6 +39,7 @@ func (c *Client) Purge(i *PurgeInput) (*Purge, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var r *Purge
 	if err := decodeJSON(&r, resp.Body); err != nil {
@@ -83,6 +84,7 @@ func (c *Client) PurgeKey(i *PurgeKeyInput) (*Purge, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var r *Purge
 	if err := decodeJSON(&r, resp.Body); err != nil {
@@ -120,6 +122,7 @@ func (c *Client) PurgeAll(i *PurgeAllInput) (*Purge, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var r *Purge
 	if err := decodeJSON(&r, resp.Body); err != nil {

--- a/request_setting.go
+++ b/request_setting.go
@@ -92,6 +92,7 @@ func (c *Client) ListRequestSettings(i *ListRequestSettingsInput) ([]*RequestSet
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var bs []*RequestSetting
 	if err := decodeJSON(&bs, resp.Body); err != nil {
@@ -138,6 +139,7 @@ func (c *Client) CreateRequestSetting(i *CreateRequestSettingInput) (*RequestSet
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var b *RequestSetting
 	if err := decodeJSON(&b, resp.Body); err != nil {
@@ -177,6 +179,7 @@ func (c *Client) GetRequestSetting(i *GetRequestSettingInput) (*RequestSetting, 
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var b *RequestSetting
 	if err := decodeJSON(&b, resp.Body); err != nil {
@@ -229,6 +232,7 @@ func (c *Client) UpdateRequestSetting(i *UpdateRequestSettingInput) (*RequestSet
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var b *RequestSetting
 	if err := decodeJSON(&b, resp.Body); err != nil {
@@ -267,6 +271,7 @@ func (c *Client) DeleteRequestSetting(i *DeleteRequestSettingInput) error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	var r *statusResp
 	if err := decodeJSON(&r, resp.Body); err != nil {

--- a/response_object.go
+++ b/response_object.go
@@ -55,6 +55,7 @@ func (c *Client) ListResponseObjects(i *ListResponseObjectsInput) ([]*ResponseOb
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var bs []*ResponseObject
 	if err := decodeJSON(&bs, resp.Body); err != nil {
@@ -96,6 +97,7 @@ func (c *Client) CreateResponseObject(i *CreateResponseObjectInput) (*ResponseOb
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var b *ResponseObject
 	if err := decodeJSON(&b, resp.Body); err != nil {
@@ -135,6 +137,7 @@ func (c *Client) GetResponseObject(i *GetResponseObjectInput) (*ResponseObject, 
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var b *ResponseObject
 	if err := decodeJSON(&b, resp.Body); err != nil {
@@ -182,6 +185,7 @@ func (c *Client) UpdateResponseObject(i *UpdateResponseObjectInput) (*ResponseOb
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var b *ResponseObject
 	if err := decodeJSON(&b, resp.Body); err != nil {
@@ -220,6 +224,7 @@ func (c *Client) DeleteResponseObject(i *DeleteResponseObjectInput) error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	var r *statusResp
 	if err := decodeJSON(&r, resp.Body); err != nil {

--- a/s3.go
+++ b/s3.go
@@ -69,6 +69,7 @@ func (c *Client) ListS3s(i *ListS3sInput) ([]*S3, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var s3s []*S3
 	if err := decodeJSON(&s3s, resp.Body); err != nil {
@@ -114,6 +115,7 @@ func (c *Client) CreateS3(i *CreateS3Input) (*S3, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var s3 *S3
 	if err := decodeJSON(&s3, resp.Body); err != nil {
@@ -152,6 +154,7 @@ func (c *Client) GetS3(i *GetS3Input) (*S3, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var s3 *S3
 	if err := decodeJSON(&s3, resp.Body); err != nil {
@@ -203,6 +206,7 @@ func (c *Client) UpdateS3(i *UpdateS3Input) (*S3, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var s3 *S3
 	if err := decodeJSON(&s3, resp.Body); err != nil {
@@ -241,6 +245,7 @@ func (c *Client) DeleteS3(i *DeleteS3Input) error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	var r *statusResp
 	if err := decodeJSON(&r, resp.Body); err != nil {

--- a/service.go
+++ b/service.go
@@ -47,6 +47,7 @@ func (c *Client) ListServices(i *ListServicesInput) ([]*Service, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var s []*Service
 	if err := decodeJSON(&s, resp.Body); err != nil {
@@ -68,6 +69,7 @@ func (c *Client) CreateService(i *CreateServiceInput) (*Service, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var s *Service
 	if err := decodeJSON(&s, resp.Body); err != nil {
@@ -94,6 +96,7 @@ func (c *Client) GetService(i *GetServiceInput) (*Service, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var s *Service
 	if err := decodeJSON(&s, resp.Body); err != nil {
@@ -115,6 +118,7 @@ func (c *Client) GetServiceDetails(i *GetServiceInput) (*ServiceDetail, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var s *ServiceDetail
 	if err := decodeJSON(&s, resp.Body); err != nil {
@@ -143,6 +147,7 @@ func (c *Client) UpdateService(i *UpdateServiceInput) (*Service, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var s *Service
 	if err := decodeJSON(&s, resp.Body); err != nil {
@@ -167,6 +172,7 @@ func (c *Client) DeleteService(i *DeleteServiceInput) error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	var r *statusResp
 	if err := decodeJSON(&r, resp.Body); err != nil {
@@ -198,6 +204,7 @@ func (c *Client) SearchService(i *SearchServiceInput) (*Service, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var s *Service
 	if err := decodeJSON(&s, resp.Body); err != nil {

--- a/settings.go
+++ b/settings.go
@@ -34,6 +34,7 @@ func (c *Client) GetSettings(i *GetSettingsInput) (*Settings, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var b *Settings
 	if err := decodeJSON(&b, resp.Body); err != nil {
@@ -68,6 +69,7 @@ func (c *Client) UpdateSettings(i *UpdateSettingsInput) (*Settings, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var b *Settings
 	if err := decodeJSON(&b, resp.Body); err != nil {

--- a/sumologic.go
+++ b/sumologic.go
@@ -55,6 +55,7 @@ func (c *Client) ListSumologics(i *ListSumologicsInput) ([]*Sumologic, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var ss []*Sumologic
 	if err := decodeJSON(&ss, resp.Body); err != nil {
@@ -93,6 +94,7 @@ func (c *Client) CreateSumologic(i *CreateSumologicInput) (*Sumologic, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var s *Sumologic
 	if err := decodeJSON(&s, resp.Body); err != nil {
@@ -131,6 +133,7 @@ func (c *Client) GetSumologic(i *GetSumologicInput) (*Sumologic, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var s *Sumologic
 	if err := decodeJSON(&s, resp.Body); err != nil {
@@ -175,6 +178,7 @@ func (c *Client) UpdateSumologic(i *UpdateSumologicInput) (*Sumologic, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var s *Sumologic
 	if err := decodeJSON(&s, resp.Body); err != nil {
@@ -213,6 +217,7 @@ func (c *Client) DeleteSumologic(i *DeleteSumologicInput) error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	var r *statusResp
 	if err := decodeJSON(&r, resp.Body); err != nil {

--- a/syslog.go
+++ b/syslog.go
@@ -58,6 +58,7 @@ func (c *Client) ListSyslogs(i *ListSyslogsInput) ([]*Syslog, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var ss []*Syslog
 	if err := decodeJSON(&ss, resp.Body); err != nil {
@@ -99,6 +100,7 @@ func (c *Client) CreateSyslog(i *CreateSyslogInput) (*Syslog, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var s *Syslog
 	if err := decodeJSON(&s, resp.Body); err != nil {
@@ -137,6 +139,7 @@ func (c *Client) GetSyslog(i *GetSyslogInput) (*Syslog, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var s *Syslog
 	if err := decodeJSON(&s, resp.Body); err != nil {
@@ -184,6 +187,7 @@ func (c *Client) UpdateSyslog(i *UpdateSyslogInput) (*Syslog, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var s *Syslog
 	if err := decodeJSON(&s, resp.Body); err != nil {
@@ -222,6 +226,7 @@ func (c *Client) DeleteSyslog(i *DeleteSyslogInput) error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	var r *statusResp
 	if err := decodeJSON(&r, resp.Body); err != nil {

--- a/vcl.go
+++ b/vcl.go
@@ -49,6 +49,7 @@ func (c *Client) ListVCLs(i *ListVCLsInput) ([]*VCL, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var vcls []*VCL
 	if err := decodeJSON(&vcls, resp.Body); err != nil {
@@ -88,6 +89,7 @@ func (c *Client) GetVCL(i *GetVCLInput) (*VCL, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var vcl *VCL
 	if err := decodeJSON(&vcl, resp.Body); err != nil {
@@ -119,6 +121,7 @@ func (c *Client) GetGeneratedVCL(i *GetGeneratedVCLInput) (*VCL, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var vcl *VCL
 	if err := decodeJSON(&vcl, resp.Body); err != nil {
@@ -153,6 +156,7 @@ func (c *Client) CreateVCL(i *CreateVCLInput) (*VCL, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var vcl *VCL
 	if err := decodeJSON(&vcl, resp.Body); err != nil {
@@ -194,6 +198,7 @@ func (c *Client) UpdateVCL(i *UpdateVCLInput) (*VCL, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var vcl *VCL
 	if err := decodeJSON(&vcl, resp.Body); err != nil {
@@ -232,6 +237,7 @@ func (c *Client) ActivateVCL(i *ActivateVCLInput) (*VCL, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var vcl *VCL
 	if err := decodeJSON(&vcl, resp.Body); err != nil {
@@ -270,6 +276,7 @@ func (c *Client) DeleteVCL(i *DeleteVCLInput) error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	var r *statusResp
 	if err := decodeJSON(&r, resp.Body); err != nil {

--- a/version.go
+++ b/version.go
@@ -45,6 +45,7 @@ func (c *Client) ListVersions(i *ListVersionsInput) ([]*Version, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var e []*Version
 	if err := decodeJSON(&e, resp.Body); err != nil {
@@ -100,6 +101,7 @@ func (c *Client) CreateVersion(i *CreateVersionInput) (*Version, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var e *Version
 	if err := decodeJSON(&e, resp.Body); err != nil {
@@ -132,6 +134,7 @@ func (c *Client) GetVersion(i *GetVersionInput) (*Version, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var e *Version
 	if err := decodeJSON(&e, resp.Body); err != nil {
@@ -165,6 +168,7 @@ func (c *Client) UpdateVersion(i *UpdateVersionInput) (*Version, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var e *Version
 	if err := decodeJSON(&e, resp.Body); err != nil {
@@ -196,6 +200,7 @@ func (c *Client) ActivateVersion(i *ActivateVersionInput) (*Version, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var e *Version
 	if err := decodeJSON(&e, resp.Body); err != nil {
@@ -227,6 +232,7 @@ func (c *Client) DeactivateVersion(i *DeactivateVersionInput) (*Version, error) 
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var e *Version
 	if err := decodeJSON(&e, resp.Body); err != nil {
@@ -260,6 +266,7 @@ func (c *Client) CloneVersion(i *CloneVersionInput) (*Version, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var e *Version
 	if err := decodeJSON(&e, resp.Body); err != nil {
@@ -293,6 +300,7 @@ func (c *Client) ValidateVersion(i *ValidateVersionInput) (bool, string, error) 
 	if err != nil {
 		return false, msg, err
 	}
+	defer resp.Body.Close()
 
 	var r *statusResp
 	if err := decodeJSON(&r, resp.Body); err != nil {
@@ -326,6 +334,7 @@ func (c *Client) LockVersion(i *LockVersionInput) (*Version, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var e *Version
 	if err := decodeJSON(&e, resp.Body); err != nil {

--- a/wordpress.go
+++ b/wordpress.go
@@ -48,6 +48,7 @@ func (c *Client) ListWordpresses(i *ListWordpressesInput) ([]*Wordpress, error) 
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var bs []*Wordpress
 	if err := decodeJSON(&bs, resp.Body); err != nil {
@@ -84,6 +85,7 @@ func (c *Client) CreateWordpress(i *CreateWordpressInput) (*Wordpress, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var b *Wordpress
 	if err := decodeJSON(&b, resp.Body); err != nil {
@@ -122,6 +124,7 @@ func (c *Client) GetWordpress(i *GetWordpressInput) (*Wordpress, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var b *Wordpress
 	if err := decodeJSON(&b, resp.Body); err != nil {
@@ -164,6 +167,7 @@ func (c *Client) UpdateWordpress(i *UpdateWordpressInput) (*Wordpress, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var b *Wordpress
 	if err := decodeJSON(&b, resp.Body); err != nil {
@@ -202,6 +206,7 @@ func (c *Client) DeleteWordpress(i *DeleteWordpressInput) error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	var r *statusResp
 	if err := decodeJSON(&r, resp.Body); err != nil {


### PR DESCRIPTION
Without this, long-running programs will build up dead sockets, eventually leading to FD limits.