### PR TITLE
Add additional fields to the calls that set up sumologic logging

### DIFF
--- a/fixtures/sumologics/create.yaml
+++ b/fixtures/sumologics/create.yaml
@@ -14,6 +14,10 @@ interactions:
       - test-sumologic
       url:
       - example.com
+      message_type:
+      - classic
+      format_version:
+      - 1
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
@@ -24,7 +28,7 @@ interactions:
     url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/609/logging/sumologic
     method: POST
   response:
-    body: '{"format":"format","name":"test-sumologic","url":"example.com","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":"609","format_version":"1","response_condition":"","updated_at":"2016-06-29T22:27:45+00:00","deleted_at":null,"created_at":"2016-06-29T22:27:45+00:00"}'
+    body: '{"format":"format","name":"test-sumologic","url":"example.com","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":"609","format_version":"1","response_condition":"","updated_at":"2016-06-29T22:27:45+00:00","deleted_at":null,"created_at":"2016-06-29T22:27:45+00:00","message_type":"classic"}'
     headers:
       Accept-Ranges:
       - bytes

--- a/fixtures/sumologics/get.yaml
+++ b/fixtures/sumologics/get.yaml
@@ -12,7 +12,7 @@ interactions:
     url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/609/logging/sumologic/test-sumologic
     method: GET
   response:
-    body: '{"format_version":"1","response_condition":"","url":"example.com","updated_at":"2016-06-29T22:27:45+00:00","name":"test-sumologic","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":"609","deleted_at":null,"created_at":"2016-06-29T22:27:45+00:00","format":"format"}'
+    body: '{"format_version":"1","response_condition":"","url":"example.com","updated_at":"2016-06-29T22:27:45+00:00","name":"test-sumologic","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":"609","deleted_at":null,"created_at":"2016-06-29T22:27:45+00:00","format":"format","message_type":"classic"}'
     headers:
       Accept-Ranges:
       - bytes

--- a/fixtures/sumologics/list.yaml
+++ b/fixtures/sumologics/list.yaml
@@ -12,7 +12,7 @@ interactions:
     url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/609/logging/sumologic
     method: GET
   response:
-    body: '[{"format_version":"1","response_condition":"","url":"example.com","updated_at":"2016-06-29T22:27:45+00:00","name":"test-sumologic","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":"609","deleted_at":null,"created_at":"2016-06-29T22:27:45+00:00","format":"format"}]'
+    body: '[{"format_version":"1","response_condition":"","url":"example.com","updated_at":"2016-06-29T22:27:45+00:00","name":"test-sumologic","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":"609","deleted_at":null,"created_at":"2016-06-29T22:27:45+00:00","format":"format","message_type":"classic"}]'
     headers:
       Accept-Ranges:
       - bytes

--- a/fixtures/sumologics/update.yaml
+++ b/fixtures/sumologics/update.yaml
@@ -22,7 +22,7 @@ interactions:
     url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/609/logging/sumologic/test-sumologic
     method: PUT
   response:
-    body: '{"format_version":"1","response_condition":"","url":"example.com","updated_at":"2016-06-29T22:27:45+00:00","name":"new-test-sumologic","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":"609","deleted_at":null,"created_at":"2016-06-29T22:27:45+00:00","format":"format"}'
+    body: '{"format_version":"1","response_condition":"","url":"example.com","updated_at":"2016-06-29T22:27:45+00:00","name":"new-test-sumologic","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":"609","deleted_at":null,"created_at":"2016-06-29T22:27:45+00:00","format":"format","message_type":"classic"}'
     headers:
       Accept-Ranges:
       - bytes

--- a/sumologic.go
+++ b/sumologic.go
@@ -16,6 +16,8 @@ type Sumologic struct {
 	URL               string     `mapstructure:"url"`
 	Format            string     `mapstructure:"format"`
 	ResponseCondition string     `mapstructure:"response_condition"`
+	MessageType       string     `mapstructure:"message_type"`
+	FormatVersion     int        `mapstructure:"format_version"`
 	CreatedAt         *time.Time `mapstructure:"created_at"`
 	UpdatedAt         *time.Time `mapstructure:"updated_at"`
 	DeletedAt         *time.Time `mapstructure:"deleted_at"`
@@ -76,6 +78,8 @@ type CreateSumologicInput struct {
 	URL               string `form:"url,omitempty"`
 	Format            string `form:"format,omitempty"`
 	ResponseCondition string `form:"response_condition,omitempty"`
+	MessageType       string `form:"message_type,omitempty"`
+	FormatVersion     int    `form:"format_version,omitempty"`
 }
 
 // CreateSumologic creates a new Fastly sumologic.
@@ -154,6 +158,8 @@ type UpdateSumologicInput struct {
 	URL               string `form:"url,omitempty"`
 	Format            string `form:"format,omitempty"`
 	ResponseCondition string `form:"response_condition,omitempty"`
+	MessageType       string `form:"message_type,omitempty"`
+	FormatVersion     int    `form:"format_version,omitempty"`
 }
 
 // UpdateSumologic updates a specific sumologic.

--- a/sumologic_test.go
+++ b/sumologic_test.go
@@ -15,11 +15,13 @@ func TestClient_Sumologics(t *testing.T) {
 	var s *Sumologic
 	record(t, "sumologics/create", func(c *Client) {
 		s, err = c.CreateSumologic(&CreateSumologicInput{
-			Service: testServiceID,
-			Version: tv.Number,
-			Name:    "test-sumologic",
-			URL:     "example.com",
-			Format:  "format",
+			Service:       testServiceID,
+			Version:       tv.Number,
+			Name:          "test-sumologic",
+			URL:           "example.com",
+			Format:        "format",
+			FormatVersion: 1,
+			MessageType:   "classic",
 		})
 	})
 	if err != nil {
@@ -51,6 +53,12 @@ func TestClient_Sumologics(t *testing.T) {
 	}
 	if s.Format != "format" {
 		t.Errorf("bad format: %q", s.Format)
+	}
+	if s.FormatVersion != 1 {
+		t.Error("bad format version: %q", s.FormatVersion)
+	}
+	if s.MessageType != "classic" {
+		t.Error("bad message type: %q", s.MessageType)
 	}
 
 	// List
@@ -88,6 +96,12 @@ func TestClient_Sumologics(t *testing.T) {
 	}
 	if s.Format != ns.Format {
 		t.Errorf("bad format: %q", s.Format)
+	}
+	if s.FormatVersion != ns.FormatVersion {
+		t.Error("bad format version: %q", s.FormatVersion)
+	}
+	if s.MessageType != ns.MessageType {
+		t.Error("bad message type: %q", s.MessageType)
 	}
 
 	// Update


### PR DESCRIPTION
This adds two missing fields that are available in the Fastly API for setting up Sumologic logging - `format_version` and `message_type`.

