### PR TITLE
Fix failing tests for RawRequest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: go
 
 go:
   - 1.6
+  - 1.8
 
 branches:
   only:

--- a/request_test.go
+++ b/request_test.go
@@ -22,7 +22,11 @@ func TestClient_RawRequest(t *testing.T) {
 	}
 	c := &Client{}
 	for _, h := range validAPIHosts {
-		c.url = &url.URL{Path: h}
+		var err error
+		c.url, err = url.Parse(h)
+		if err != nil {
+			t.Fatalf("Unable to parse url %s: %s\n", h, err)
+		}
 		for _, p := range purgeAPIPaths {
 			for _, k := range cacheKeys {
 				r, err := c.RawRequest("GET", p+k, nil)
@@ -39,11 +43,11 @@ func TestClient_RawRequest(t *testing.T) {
 				// Insure we don't get a path starting with an extra slash
 				// e.g. //service/myservice/purge/mykey
 				if r.URL.Path[1] == '/' {
-					t.Fatal("Host and APIPath were joined incorrectly.")
+					t.Fatalf("Host and APIPath were joined incorrectly. Got: %s\n", r.URL.Path)
 				}
 				// Insure the cache key isn't altered
 				if strings.Index(r.URL.Path, p+k) == -1 {
-					t.Fatal("RawRequest altered the cache key")
+					t.Fatalf("RawRequest altered the cache key. New URL path=%s, expecting %s\n", p+k)
 				}
 			}
 		}


### PR DESCRIPTION
While trying to fix another issue I had I encountered the following errors while running the tests:
```
$ make test
==> Generating...
==> Running tests...
--- FAIL: TestClient_RawRequest (0.00s)
        request_test.go:33: Path returned:  ./https://api.fastly.com/service/myservice/purge//
        request_test.go:38: Path expected:  /service/myservice/purge//
        request_test.go:42: Host and APIPath were joined incorrectly.
FAIL
FAIL    github.com/sethvargo/go-fastly  0.455s
make: *** [test] Error 1
```

A big part of it was due to the fact that the test was assigning a domain url to a path when the pas is only the part coming after the domain. Also added a little more explanations in the error messages for easier debugging.

Also to avoid some repetitive double slash (to have a cleaner url) I changed a bit the `RawRequest` function to use a `strings.Replace`, avoiding url like `https://api.fastly.com/service/myservice/purge//` or `https://api.fastly.com/https://releases.hashicorp.com`.

This made me change the purge fixture as it was having a double slash in the url, so failing the test:
```
$ make test
==> Generating...
==> Running tests...
--- FAIL: TestClient_Purge (0.04s)
        purge_test.go:16: Purge https://api.fastly.com/https:/releases.hashicorp.com: Requested interaction not found
FAIL
FAIL    github.com/sethvargo/go-fastly  0.428s
make: *** [test] Error 1
```
Note: I'm running golang 1.8 (so I added go 1.8 to the `.travis.yml` as it might be why the issue went undetected):
```
$ go version
go version go1.8 darwin/amd64
```

Would you be ok integrating that?

Thanks
Joseph
