### PR TITLE
Fix the sorting of the versions to be based on numbers and not literals

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -8,7 +8,7 @@ import (
 // Backend represents a backend response from the Fastly API.
 type Backend struct {
 	ServiceID string `mapstructure:"service_id"`
-	Version   string `mapstructure:"version"`
+	Version   int    `mapstructure:"version"`
 
 	Name                string   `mapstructure:"name"`
 	Address             string   `mapstructure:"address"`
@@ -53,7 +53,7 @@ type ListBackendsInput struct {
 	Service string
 
 	// Version is the specific configuration version (required).
-	Version string
+	Version int
 }
 
 // ListBackends returns the list of backends for the configuration version.
@@ -62,11 +62,11 @@ func (c *Client) ListBackends(i *ListBackendsInput) ([]*Backend, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/backend", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/backend", i.Service, i.Version)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -85,7 +85,7 @@ type CreateBackendInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	Name                string       `form:"name,omitempty"`
 	Address             string       `form:"address,omitempty"`
@@ -119,11 +119,11 @@ func (c *Client) CreateBackend(i *CreateBackendInput) (*Backend, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/backend", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/backend", i.Service, i.Version)
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -141,7 +141,7 @@ type GetBackendInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the backend to fetch.
 	Name string
@@ -153,7 +153,7 @@ func (c *Client) GetBackend(i *GetBackendInput) (*Backend, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -161,7 +161,7 @@ func (c *Client) GetBackend(i *GetBackendInput) (*Backend, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/backend/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/backend/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -179,7 +179,7 @@ type UpdateBackendInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the backend to update.
 	Name string
@@ -216,7 +216,7 @@ func (c *Client) UpdateBackend(i *UpdateBackendInput) (*Backend, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -224,7 +224,7 @@ func (c *Client) UpdateBackend(i *UpdateBackendInput) (*Backend, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/backend/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/backend/%s", i.Service, i.Version, i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -242,7 +242,7 @@ type DeleteBackendInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the backend to delete (required).
 	Name string
@@ -254,7 +254,7 @@ func (c *Client) DeleteBackend(i *DeleteBackendInput) error {
 		return ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return ErrMissingVersion
 	}
 
@@ -262,7 +262,7 @@ func (c *Client) DeleteBackend(i *DeleteBackendInput) error {
 		return ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/backend/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/backend/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/backend_test.go
+++ b/backend_test.go
@@ -138,7 +138,7 @@ func TestClient_ListBackends_validation(t *testing.T) {
 
 	_, err = testClient.ListBackends(&ListBackendsInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -156,7 +156,7 @@ func TestClient_CreateBackend_validation(t *testing.T) {
 
 	_, err = testClient.CreateBackend(&CreateBackendInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -174,7 +174,7 @@ func TestClient_GetBackend_validation(t *testing.T) {
 
 	_, err = testClient.GetBackend(&GetBackendInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -182,7 +182,7 @@ func TestClient_GetBackend_validation(t *testing.T) {
 
 	_, err = testClient.GetBackend(&GetBackendInput{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {
@@ -201,7 +201,7 @@ func TestClient_UpdateBackend_validation(t *testing.T) {
 
 	_, err = testClient.UpdateBackend(&UpdateBackendInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -209,7 +209,7 @@ func TestClient_UpdateBackend_validation(t *testing.T) {
 
 	_, err = testClient.UpdateBackend(&UpdateBackendInput{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {
@@ -228,7 +228,7 @@ func TestClient_DeleteBackend_validation(t *testing.T) {
 
 	err = testClient.DeleteBackend(&DeleteBackendInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -236,7 +236,7 @@ func TestClient_DeleteBackend_validation(t *testing.T) {
 
 	err = testClient.DeleteBackend(&DeleteBackendInput{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {

--- a/cache_setting.go
+++ b/cache_setting.go
@@ -22,7 +22,7 @@ type CacheSettingAction string
 // CacheSetting represents a response from Fastly's API for cache settings.
 type CacheSetting struct {
 	ServiceID string `mapstructure:"service_id"`
-	Version   string `mapstructure:"version"`
+	Version   int    `mapstructure:"version"`
 
 	Name           string             `mapstructure:"name"`
 	Action         CacheSettingAction `mapstructure:"action"`
@@ -47,7 +47,7 @@ type ListCacheSettingsInput struct {
 	Service string
 
 	// Version is the specific configuration version (required).
-	Version string
+	Version int
 }
 
 // ListCacheSettings returns the list of cache settings for the configuration
@@ -57,11 +57,11 @@ func (c *Client) ListCacheSettings(i *ListCacheSettingsInput) ([]*CacheSetting, 
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/cache_settings", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/cache_settings", i.Service, i.Version)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -80,7 +80,7 @@ type CreateCacheSettingInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	Name           string             `form:"name,omitempty"`
 	Action         CacheSettingAction `form:"action,omitempty"`
@@ -95,11 +95,11 @@ func (c *Client) CreateCacheSetting(i *CreateCacheSettingInput) (*CacheSetting, 
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/cache_settings", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/cache_settings", i.Service, i.Version)
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -117,7 +117,7 @@ type GetCacheSettingInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the cache setting to fetch.
 	Name string
@@ -130,7 +130,7 @@ func (c *Client) GetCacheSetting(i *GetCacheSettingInput) (*CacheSetting, error)
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -138,7 +138,7 @@ func (c *Client) GetCacheSetting(i *GetCacheSettingInput) (*CacheSetting, error)
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/cache_settings/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/cache_settings/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -156,7 +156,7 @@ type UpdateCacheSettingInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the cache setting to update.
 	Name string
@@ -174,7 +174,7 @@ func (c *Client) UpdateCacheSetting(i *UpdateCacheSettingInput) (*CacheSetting, 
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -182,7 +182,7 @@ func (c *Client) UpdateCacheSetting(i *UpdateCacheSettingInput) (*CacheSetting, 
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/cache_settings/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/cache_settings/%s", i.Service, i.Version, i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -200,7 +200,7 @@ type DeleteCacheSettingInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the cache setting to delete (required).
 	Name string
@@ -212,7 +212,7 @@ func (c *Client) DeleteCacheSetting(i *DeleteCacheSettingInput) error {
 		return ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return ErrMissingVersion
 	}
 
@@ -220,7 +220,7 @@ func (c *Client) DeleteCacheSetting(i *DeleteCacheSettingInput) error {
 		return ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/cache_settings/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/cache_settings/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/cache_setting_test.go
+++ b/cache_setting_test.go
@@ -138,7 +138,7 @@ func TestClient_ListCacheSettings_validation(t *testing.T) {
 
 	_, err = testClient.ListCacheSettings(&ListCacheSettingsInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -156,7 +156,7 @@ func TestClient_CreateCacheSetting_validation(t *testing.T) {
 
 	_, err = testClient.CreateCacheSetting(&CreateCacheSettingInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -174,7 +174,7 @@ func TestClient_GetCacheSetting_validation(t *testing.T) {
 
 	_, err = testClient.GetCacheSetting(&GetCacheSettingInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -182,7 +182,7 @@ func TestClient_GetCacheSetting_validation(t *testing.T) {
 
 	_, err = testClient.GetCacheSetting(&GetCacheSettingInput{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {
@@ -201,7 +201,7 @@ func TestClient_UpdateCacheSetting_validation(t *testing.T) {
 
 	_, err = testClient.UpdateCacheSetting(&UpdateCacheSettingInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -209,7 +209,7 @@ func TestClient_UpdateCacheSetting_validation(t *testing.T) {
 
 	_, err = testClient.UpdateCacheSetting(&UpdateCacheSettingInput{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {
@@ -228,7 +228,7 @@ func TestClient_DeleteCacheSetting_validation(t *testing.T) {
 
 	err = testClient.DeleteCacheSetting(&DeleteCacheSettingInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -236,7 +236,7 @@ func TestClient_DeleteCacheSetting_validation(t *testing.T) {
 
 	err = testClient.DeleteCacheSetting(&DeleteCacheSettingInput{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {

--- a/condition.go
+++ b/condition.go
@@ -8,7 +8,7 @@ import (
 // Condition represents a condition response from the Fastly API.
 type Condition struct {
 	ServiceID string `mapstructure:"service_id"`
-	Version   string `mapstructure:"version"`
+	Version   int    `mapstructure:"version"`
 
 	Name      string `mapstructure:"name"`
 	Statement string `mapstructure:"statement"`
@@ -32,7 +32,7 @@ type ListConditionsInput struct {
 	Service string
 
 	// Version is the specific configuration version (required).
-	Version string
+	Version int
 }
 
 // ListConditions returns the list of conditions for the configuration version.
@@ -41,11 +41,11 @@ func (c *Client) ListConditions(i *ListConditionsInput) ([]*Condition, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/condition", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/condition", i.Service, i.Version)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -64,7 +64,7 @@ type CreateConditionInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	Name      string `form:"name,omitempty"`
 	Statement string `form:"statement,omitempty"`
@@ -78,11 +78,11 @@ func (c *Client) CreateCondition(i *CreateConditionInput) (*Condition, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/condition", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/condition", i.Service, i.Version)
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -100,7 +100,7 @@ type GetConditionInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the condition to fetch.
 	Name string
@@ -112,7 +112,7 @@ func (c *Client) GetCondition(i *GetConditionInput) (*Condition, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -120,7 +120,7 @@ func (c *Client) GetCondition(i *GetConditionInput) (*Condition, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/condition/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/condition/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -138,7 +138,7 @@ type UpdateConditionInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the condition to update.
 	Name string
@@ -154,7 +154,7 @@ func (c *Client) UpdateCondition(i *UpdateConditionInput) (*Condition, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -162,7 +162,7 @@ func (c *Client) UpdateCondition(i *UpdateConditionInput) (*Condition, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/condition/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/condition/%s", i.Service, i.Version, i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -180,7 +180,7 @@ type DeleteConditionInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the condition to delete (required).
 	Name string
@@ -192,7 +192,7 @@ func (c *Client) DeleteCondition(i *DeleteConditionInput) error {
 		return ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return ErrMissingVersion
 	}
 
@@ -200,7 +200,7 @@ func (c *Client) DeleteCondition(i *DeleteConditionInput) error {
 		return ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/condition/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/condition/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/condition_test.go
+++ b/condition_test.go
@@ -132,7 +132,7 @@ func TestClient_ListConditions_validation(t *testing.T) {
 
 	_, err = testClient.ListConditions(&ListConditionsInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -150,7 +150,7 @@ func TestClient_CreateCondition_validation(t *testing.T) {
 
 	_, err = testClient.CreateCondition(&CreateConditionInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -168,7 +168,7 @@ func TestClient_GetCondition_validation(t *testing.T) {
 
 	_, err = testClient.GetCondition(&GetConditionInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -176,7 +176,7 @@ func TestClient_GetCondition_validation(t *testing.T) {
 
 	_, err = testClient.GetCondition(&GetConditionInput{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {
@@ -195,7 +195,7 @@ func TestClient_UpdateCondition_validation(t *testing.T) {
 
 	_, err = testClient.UpdateCondition(&UpdateConditionInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -203,7 +203,7 @@ func TestClient_UpdateCondition_validation(t *testing.T) {
 
 	_, err = testClient.UpdateCondition(&UpdateConditionInput{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {
@@ -222,7 +222,7 @@ func TestClient_DeleteCondition_validation(t *testing.T) {
 
 	err = testClient.DeleteCondition(&DeleteConditionInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -230,7 +230,7 @@ func TestClient_DeleteCondition_validation(t *testing.T) {
 
 	err = testClient.DeleteCondition(&DeleteConditionInput{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {

--- a/dictionary.go
+++ b/dictionary.go
@@ -8,7 +8,7 @@ import (
 // Dictionary represents a dictionary response from the Fastly API.
 type Dictionary struct {
 	ServiceID string `mapstructure:"service_id"`
-	Version   string `mapstructure:"version"`
+	Version   int    `mapstructure:"version"`
 
 	ID      string `mapstructure:"id"`
 	Name    string `mapstructure:"name"`
@@ -31,7 +31,7 @@ type ListDictionariesInput struct {
 	Service string
 
 	// Version is the specific configuration version (required).
-	Version string
+	Version int
 }
 
 // ListDictionaries returns the list of dictionaries for the configuration version.
@@ -40,11 +40,11 @@ func (c *Client) ListDictionaries(i *ListDictionariesInput) ([]*Dictionary, erro
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/dictionary", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/dictionary", i.Service, i.Version)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -63,7 +63,7 @@ type CreateDictionaryInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	Name string `form:"name,omitempty"`
 }
@@ -74,11 +74,11 @@ func (c *Client) CreateDictionary(i *CreateDictionaryInput) (*Dictionary, error)
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/dictionary", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/dictionary", i.Service, i.Version)
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -96,7 +96,7 @@ type GetDictionaryInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the dictionary to fetch.
 	Name string
@@ -108,7 +108,7 @@ func (c *Client) GetDictionary(i *GetDictionaryInput) (*Dictionary, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -116,7 +116,7 @@ func (c *Client) GetDictionary(i *GetDictionaryInput) (*Dictionary, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/dictionary/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/dictionary/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -134,7 +134,7 @@ type UpdateDictionaryInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the dictionary to update.
 	Name string
@@ -148,7 +148,7 @@ func (c *Client) UpdateDictionary(i *UpdateDictionaryInput) (*Dictionary, error)
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -156,7 +156,7 @@ func (c *Client) UpdateDictionary(i *UpdateDictionaryInput) (*Dictionary, error)
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/dictionary/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/dictionary/%s", i.Service, i.Version, i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -174,7 +174,7 @@ type DeleteDictionaryInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the dictionary to delete (required).
 	Name string
@@ -186,7 +186,7 @@ func (c *Client) DeleteDictionary(i *DeleteDictionaryInput) error {
 		return ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return ErrMissingVersion
 	}
 
@@ -194,7 +194,7 @@ func (c *Client) DeleteDictionary(i *DeleteDictionaryInput) error {
 		return ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/dictionary/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/dictionary/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/dictionary_test.go
+++ b/dictionary_test.go
@@ -117,7 +117,7 @@ func TestClient_ListDictionaries_validation(t *testing.T) {
 
 	_, err = testClient.ListDictionaries(&ListDictionariesInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -135,7 +135,7 @@ func TestClient_CreateDictionary_validation(t *testing.T) {
 
 	_, err = testClient.CreateDictionary(&CreateDictionaryInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -153,7 +153,7 @@ func TestClient_GetDictionary_validation(t *testing.T) {
 
 	_, err = testClient.GetDictionary(&GetDictionaryInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -161,7 +161,7 @@ func TestClient_GetDictionary_validation(t *testing.T) {
 
 	_, err = testClient.GetDictionary(&GetDictionaryInput{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {
@@ -180,7 +180,7 @@ func TestClient_UpdateDictionary_validation(t *testing.T) {
 
 	_, err = testClient.UpdateDictionary(&UpdateDictionaryInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -188,7 +188,7 @@ func TestClient_UpdateDictionary_validation(t *testing.T) {
 
 	_, err = testClient.UpdateDictionary(&UpdateDictionaryInput{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {
@@ -207,7 +207,7 @@ func TestClient_DeleteDictionary_validation(t *testing.T) {
 
 	err = testClient.DeleteDictionary(&DeleteDictionaryInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -215,7 +215,7 @@ func TestClient_DeleteDictionary_validation(t *testing.T) {
 
 	err = testClient.DeleteDictionary(&DeleteDictionaryInput{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {

--- a/diff.go
+++ b/diff.go
@@ -5,8 +5,8 @@ import "fmt"
 // Diff represents a diff of two versions as a response from the Fastly API.
 type Diff struct {
 	Format string `mapstructure:"format"`
-	From   string `mapstructure:"from"`
-	To     string `mapstructure:"to"`
+	From   int    `mapstructure:"from"`
+	To     int    `mapstructure:"to"`
 	Diff   string `mapstructure:"diff"`
 }
 
@@ -18,10 +18,10 @@ type GetDiffInput struct {
 	// From is the version to diff from. This can either be a string indicating a
 	// positive number (e.g. "1") or a negative number from "-1" down ("-1" is the
 	// latest version).
-	From string
+	From int
 
 	// To is the version to diff up to. The same rules for From apply.
-	To string
+	To int
 
 	// Format is an optional field to specify the format with which the diff will
 	// be returned. Acceptable values are "text" (default), "html", or
@@ -35,15 +35,15 @@ func (c *Client) GetDiff(i *GetDiffInput) (*Diff, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.From == "" {
+	if i.From == 0 {
 		return nil, ErrMissingFrom
 	}
 
-	if i.To == "" {
+	if i.To == 0 {
 		return nil, ErrMissingTo
 	}
 
-	path := fmt.Sprintf("service/%s/diff/from/%s/to/%s", i.Service, i.From, i.To)
+	path := fmt.Sprintf("service/%s/diff/from/%d/to/%d", i.Service, i.From, i.To)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err

--- a/diff_test.go
+++ b/diff_test.go
@@ -80,7 +80,7 @@ func TestClient_Diff_validation(t *testing.T) {
 
 	_, err = testClient.GetDiff(&GetDiffInput{
 		Service: "foo",
-		From:    "",
+		From:    0,
 	})
 	if err != ErrMissingFrom {
 		t.Errorf("bad error: %s", err)
@@ -88,8 +88,8 @@ func TestClient_Diff_validation(t *testing.T) {
 
 	_, err = testClient.GetDiff(&GetDiffInput{
 		Service: "foo",
-		From:    "1",
-		To:      "",
+		From:    1,
+		To:      0,
 	})
 	if err != ErrMissingTo {
 		t.Errorf("bad error: %s", err)

--- a/director.go
+++ b/director.go
@@ -25,7 +25,7 @@ type DirectorType uint8
 // Director represents a director response from the Fastly API.
 type Director struct {
 	ServiceID string `mapstructure:"service_id"`
-	Version   string `mapstructure:"version"`
+	Version   int    `mapstructure:"version"`
 
 	Name     string       `mapstructure:"name"`
 	Comment  string       `mapstructure:"comment"`
@@ -51,7 +51,7 @@ type ListDirectorsInput struct {
 	Service string
 
 	// Version is the specific configuration version (required).
-	Version string
+	Version int
 }
 
 // ListDirectors returns the list of directors for the configuration version.
@@ -60,11 +60,11 @@ func (c *Client) ListDirectors(i *ListDirectorsInput) ([]*Director, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/director", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/director", i.Service, i.Version)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -83,7 +83,7 @@ type CreateDirectorInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	Name    string       `form:"name,omitempty"`
 	Comment string       `form:"comment,omitempty"`
@@ -98,11 +98,11 @@ func (c *Client) CreateDirector(i *CreateDirectorInput) (*Director, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/director", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/director", i.Service, i.Version)
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -120,7 +120,7 @@ type GetDirectorInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the director to fetch.
 	Name string
@@ -132,7 +132,7 @@ func (c *Client) GetDirector(i *GetDirectorInput) (*Director, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -140,7 +140,7 @@ func (c *Client) GetDirector(i *GetDirectorInput) (*Director, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/director/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/director/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -158,7 +158,7 @@ type UpdateDirectorInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the director to update.
 	Name string
@@ -175,7 +175,7 @@ func (c *Client) UpdateDirector(i *UpdateDirectorInput) (*Director, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -183,7 +183,7 @@ func (c *Client) UpdateDirector(i *UpdateDirectorInput) (*Director, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/director/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/director/%s", i.Service, i.Version, i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -201,7 +201,7 @@ type DeleteDirectorInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the director to delete (required).
 	Name string
@@ -213,7 +213,7 @@ func (c *Client) DeleteDirector(i *DeleteDirectorInput) error {
 		return ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return ErrMissingVersion
 	}
 
@@ -221,7 +221,7 @@ func (c *Client) DeleteDirector(i *DeleteDirectorInput) error {
 		return ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/director/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/director/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/director_backend.go
+++ b/director_backend.go
@@ -9,7 +9,7 @@ import (
 // Fastly API.
 type DirectorBackend struct {
 	ServiceID string `mapstructure:"service_id"`
-	Version   string `mapstructure:"version"`
+	Version   int    `mapstructure:"version"`
 
 	Director  string     `mapstructure:"director_name"`
 	Backend   string     `mapstructure:"backend_name"`
@@ -24,7 +24,7 @@ type CreateDirectorBackendInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Director is the name of the director (required).
 	Director string
@@ -39,7 +39,7 @@ func (c *Client) CreateDirectorBackend(i *CreateDirectorBackendInput) (*Director
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -51,7 +51,7 @@ func (c *Client) CreateDirectorBackend(i *CreateDirectorBackendInput) (*Director
 		return nil, ErrMissingBackend
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/director/%s/backend/%s",
+	path := fmt.Sprintf("/service/%s/version/%d/director/%s/backend/%s",
 		i.Service, i.Version, i.Director, i.Backend)
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
@@ -70,7 +70,7 @@ type GetDirectorBackendInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Director is the name of the director (required).
 	Director string
@@ -85,7 +85,7 @@ func (c *Client) GetDirectorBackend(i *GetDirectorBackendInput) (*DirectorBacken
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -97,7 +97,7 @@ func (c *Client) GetDirectorBackend(i *GetDirectorBackendInput) (*DirectorBacken
 		return nil, ErrMissingBackend
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/director/%s/backend/%s",
+	path := fmt.Sprintf("/service/%s/version/%d/director/%s/backend/%s",
 		i.Service, i.Version, i.Director, i.Backend)
 	resp, err := c.Get(path, nil)
 	if err != nil {
@@ -116,7 +116,7 @@ type DeleteDirectorBackendInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Director is the name of the director (required).
 	Director string
@@ -131,7 +131,7 @@ func (c *Client) DeleteDirectorBackend(i *DeleteDirectorBackendInput) error {
 		return ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return ErrMissingVersion
 	}
 
@@ -143,7 +143,7 @@ func (c *Client) DeleteDirectorBackend(i *DeleteDirectorBackendInput) error {
 		return ErrMissingBackend
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/director/%s/backend/%s",
+	path := fmt.Sprintf("/service/%s/version/%d/director/%s/backend/%s",
 		i.Service, i.Version, i.Director, i.Backend)
 	resp, err := c.Delete(path, nil)
 	if err != nil {

--- a/director_backend_test.go
+++ b/director_backend_test.go
@@ -90,7 +90,7 @@ func TestClient_CreateDirectorBackend_validation(t *testing.T) {
 
 	_, err = testClient.CreateDirectorBackend(&CreateDirectorBackendInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -108,7 +108,7 @@ func TestClient_GetDirectorBackend_validation(t *testing.T) {
 
 	_, err = testClient.GetDirectorBackend(&GetDirectorBackendInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -116,7 +116,7 @@ func TestClient_GetDirectorBackend_validation(t *testing.T) {
 
 	_, err = testClient.GetDirectorBackend(&GetDirectorBackendInput{
 		Service:  "foo",
-		Version:  "1",
+		Version:  1,
 		Director: "",
 	})
 	if err != ErrMissingDirector {
@@ -125,7 +125,7 @@ func TestClient_GetDirectorBackend_validation(t *testing.T) {
 
 	_, err = testClient.GetDirectorBackend(&GetDirectorBackendInput{
 		Service:  "foo",
-		Version:  "1",
+		Version:  1,
 		Director: "director",
 		Backend:  "",
 	})
@@ -145,7 +145,7 @@ func TestClient_DeleteDirectorBackend_validation(t *testing.T) {
 
 	err = testClient.DeleteDirectorBackend(&DeleteDirectorBackendInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -153,7 +153,7 @@ func TestClient_DeleteDirectorBackend_validation(t *testing.T) {
 
 	err = testClient.DeleteDirectorBackend(&DeleteDirectorBackendInput{
 		Service:  "foo",
-		Version:  "1",
+		Version:  1,
 		Director: "",
 	})
 	if err != ErrMissingDirector {
@@ -162,7 +162,7 @@ func TestClient_DeleteDirectorBackend_validation(t *testing.T) {
 
 	err = testClient.DeleteDirectorBackend(&DeleteDirectorBackendInput{
 		Service:  "foo",
-		Version:  "1",
+		Version:  1,
 		Director: "director",
 		Backend:  "",
 	})

--- a/director_test.go
+++ b/director_test.go
@@ -138,7 +138,7 @@ func TestClient_ListDirectors_validation(t *testing.T) {
 
 	_, err = testClient.ListDirectors(&ListDirectorsInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -156,7 +156,7 @@ func TestClient_CreateDirector_validation(t *testing.T) {
 
 	_, err = testClient.CreateDirector(&CreateDirectorInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -174,7 +174,7 @@ func TestClient_GetDirector_validation(t *testing.T) {
 
 	_, err = testClient.GetDirector(&GetDirectorInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -182,7 +182,7 @@ func TestClient_GetDirector_validation(t *testing.T) {
 
 	_, err = testClient.GetDirector(&GetDirectorInput{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {
@@ -201,7 +201,7 @@ func TestClient_UpdateDirector_validation(t *testing.T) {
 
 	_, err = testClient.UpdateDirector(&UpdateDirectorInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -209,7 +209,7 @@ func TestClient_UpdateDirector_validation(t *testing.T) {
 
 	_, err = testClient.UpdateDirector(&UpdateDirectorInput{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {
@@ -228,7 +228,7 @@ func TestClient_DeleteDirector_validation(t *testing.T) {
 
 	err = testClient.DeleteDirector(&DeleteDirectorInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -236,7 +236,7 @@ func TestClient_DeleteDirector_validation(t *testing.T) {
 
 	err = testClient.DeleteDirector(&DeleteDirectorInput{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {

--- a/domain.go
+++ b/domain.go
@@ -8,7 +8,7 @@ import (
 // Domain represents the the domain name Fastly will serve content for.
 type Domain struct {
 	ServiceID string `mapstructure:"service_id"`
-	Version   string `mapstructure:"version"`
+	Version   int    `mapstructure:"version"`
 
 	Name    string `mapstructure:"name"`
 	Comment string `mapstructure:"comment"`
@@ -30,7 +30,7 @@ type ListDomainsInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 }
 
 // ListDomains returns the list of domains for this Service.
@@ -39,11 +39,11 @@ func (c *Client) ListDomains(i *ListDomainsInput) ([]*Domain, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/domain", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/domain", i.Service, i.Version)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -62,7 +62,7 @@ type CreateDomainInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the domain that the service will respond to (required).
 	Name string `form:"name"`
@@ -77,11 +77,11 @@ func (c *Client) CreateDomain(i *CreateDomainInput) (*Domain, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/domain", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/domain", i.Service, i.Version)
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -99,7 +99,7 @@ type GetDomainInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the domain to fetch.
 	Name string `form:"name"`
@@ -111,7 +111,7 @@ func (c *Client) GetDomain(i *GetDomainInput) (*Domain, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -119,7 +119,7 @@ func (c *Client) GetDomain(i *GetDomainInput) (*Domain, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/domain/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/domain/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -137,7 +137,7 @@ type UpdateDomainInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the domain that the service will respond to (required).
 	Name string
@@ -156,7 +156,7 @@ func (c *Client) UpdateDomain(i *UpdateDomainInput) (*Domain, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -164,7 +164,7 @@ func (c *Client) UpdateDomain(i *UpdateDomainInput) (*Domain, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/domain/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/domain/%s", i.Service, i.Version, i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -182,7 +182,7 @@ type DeleteDomainInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the domain that the service will respond to (required).
 	Name string `form:"name"`
@@ -194,7 +194,7 @@ func (c *Client) DeleteDomain(i *DeleteDomainInput) error {
 		return ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return ErrMissingVersion
 	}
 
@@ -202,7 +202,7 @@ func (c *Client) DeleteDomain(i *DeleteDomainInput) error {
 		return ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/domain/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/domain/%s", i.Service, i.Version, i.Name)
 	_, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/domain_test.go
+++ b/domain_test.go
@@ -124,7 +124,7 @@ func TestClient_ListDomains_validation(t *testing.T) {
 
 	_, err = testClient.ListDomains(&ListDomainsInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -142,7 +142,7 @@ func TestClient_CreateDomain_validation(t *testing.T) {
 
 	_, err = testClient.CreateDomain(&CreateDomainInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -160,7 +160,7 @@ func TestClient_GetDomain_validation(t *testing.T) {
 
 	_, err = testClient.GetDomain(&GetDomainInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -168,7 +168,7 @@ func TestClient_GetDomain_validation(t *testing.T) {
 
 	_, err = testClient.GetDomain(&GetDomainInput{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {
@@ -187,7 +187,7 @@ func TestClient_UpdateDomain_validation(t *testing.T) {
 
 	_, err = testClient.UpdateDomain(&UpdateDomainInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -195,7 +195,7 @@ func TestClient_UpdateDomain_validation(t *testing.T) {
 
 	_, err = testClient.UpdateDomain(&UpdateDomainInput{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {
@@ -214,7 +214,7 @@ func TestClient_DeleteDomain_validation(t *testing.T) {
 
 	err = testClient.DeleteDomain(&DeleteDomainInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -222,7 +222,7 @@ func TestClient_DeleteDomain_validation(t *testing.T) {
 
 	err = testClient.DeleteDomain(&DeleteDomainInput{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {

--- a/ftp.go
+++ b/ftp.go
@@ -9,7 +9,7 @@ import (
 // FTP represents an FTP logging response from the Fastly API.
 type FTP struct {
 	ServiceID string `mapstructure:"service_id"`
-	Version   string `mapstructure:"version"`
+	Version   int    `mapstructure:"version"`
 
 	Name              string     `mapstructure:"name"`
 	Address           string     `mapstructure:"address"`
@@ -43,7 +43,7 @@ type ListFTPsInput struct {
 	Service string
 
 	// Version is the specific configuration version (required).
-	Version string
+	Version int
 }
 
 // ListFTPs returns the list of ftps for the configuration version.
@@ -52,11 +52,11 @@ func (c *Client) ListFTPs(i *ListFTPsInput) ([]*FTP, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/ftp", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/ftp", i.Service, i.Version)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -75,7 +75,7 @@ type CreateFTPInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	Name              string `form:"name,omitempty"`
 	Address           string `form:"address,omitempty"`
@@ -96,11 +96,11 @@ func (c *Client) CreateFTP(i *CreateFTPInput) (*FTP, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/ftp", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/ftp", i.Service, i.Version)
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -118,7 +118,7 @@ type GetFTPInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the FTP to fetch.
 	Name string
@@ -130,7 +130,7 @@ func (c *Client) GetFTP(i *GetFTPInput) (*FTP, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -138,7 +138,7 @@ func (c *Client) GetFTP(i *GetFTPInput) (*FTP, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/ftp/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/ftp/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -156,7 +156,7 @@ type UpdateFTPInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the FTP to update.
 	Name string
@@ -180,7 +180,7 @@ func (c *Client) UpdateFTP(i *UpdateFTPInput) (*FTP, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -188,7 +188,7 @@ func (c *Client) UpdateFTP(i *UpdateFTPInput) (*FTP, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/ftp/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/ftp/%s", i.Service, i.Version, i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -206,7 +206,7 @@ type DeleteFTPInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the FTP to delete (required).
 	Name string
@@ -218,7 +218,7 @@ func (c *Client) DeleteFTP(i *DeleteFTPInput) error {
 		return ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return ErrMissingVersion
 	}
 
@@ -226,7 +226,7 @@ func (c *Client) DeleteFTP(i *DeleteFTPInput) error {
 		return ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/ftp/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/ftp/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/ftp_test.go
+++ b/ftp_test.go
@@ -180,7 +180,7 @@ func TestClient_ListFTPs_validation(t *testing.T) {
 
 	_, err = testClient.ListFTPs(&ListFTPsInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -198,7 +198,7 @@ func TestClient_CreateFTP_validation(t *testing.T) {
 
 	_, err = testClient.CreateFTP(&CreateFTPInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -216,7 +216,7 @@ func TestClient_GetFTP_validation(t *testing.T) {
 
 	_, err = testClient.GetFTP(&GetFTPInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -224,7 +224,7 @@ func TestClient_GetFTP_validation(t *testing.T) {
 
 	_, err = testClient.GetFTP(&GetFTPInput{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {
@@ -243,7 +243,7 @@ func TestClient_UpdateFTP_validation(t *testing.T) {
 
 	_, err = testClient.UpdateFTP(&UpdateFTPInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -251,7 +251,7 @@ func TestClient_UpdateFTP_validation(t *testing.T) {
 
 	_, err = testClient.UpdateFTP(&UpdateFTPInput{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {
@@ -270,7 +270,7 @@ func TestClient_DeleteFTP_validation(t *testing.T) {
 
 	err = testClient.DeleteFTP(&DeleteFTPInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -278,7 +278,7 @@ func TestClient_DeleteFTP_validation(t *testing.T) {
 
 	err = testClient.DeleteFTP(&DeleteFTPInput{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {

--- a/gcs.go
+++ b/gcs.go
@@ -8,7 +8,7 @@ import (
 // GCS represents an GCS logging response from the Fastly API.
 type GCS struct {
 	ServiceID string `mapstructure:"service_id"`
-	Version   string `mapstructure:"version"`
+	Version   int    `mapstructure:"version"`
 
 	Name              string `mapstructure:"name"`
 	Bucket            string `mapstructure:"bucket_name"`
@@ -38,7 +38,7 @@ type ListGCSsInput struct {
 	Service string
 
 	// Version is the specific configuration version (required).
-	Version string
+	Version int
 }
 
 // ListGCSs returns the list of gcses for the configuration version.
@@ -47,11 +47,11 @@ func (c *Client) ListGCSs(i *ListGCSsInput) ([]*GCS, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/gcs", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/gcs", i.Service, i.Version)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -70,7 +70,7 @@ type CreateGCSInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	Name              string `form:"name,omitempty"`
 	Bucket            string `form:"bucket_name,omitempty"`
@@ -90,11 +90,11 @@ func (c *Client) CreateGCS(i *CreateGCSInput) (*GCS, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/gcs", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/gcs", i.Service, i.Version)
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -112,7 +112,7 @@ type GetGCSInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the GCS to fetch.
 	Name string
@@ -124,7 +124,7 @@ func (c *Client) GetGCS(i *GetGCSInput) (*GCS, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -132,7 +132,7 @@ func (c *Client) GetGCS(i *GetGCSInput) (*GCS, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/gcs/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/gcs/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -150,7 +150,7 @@ type UpdateGCSInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the GCS to update.
 	Name string
@@ -173,7 +173,7 @@ func (c *Client) UpdateGCS(i *UpdateGCSInput) (*GCS, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -181,7 +181,7 @@ func (c *Client) UpdateGCS(i *UpdateGCSInput) (*GCS, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/gcs/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/gcs/%s", i.Service, i.Version, i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -199,7 +199,7 @@ type DeleteGCSInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the GCS to delete (required).
 	Name string
@@ -211,7 +211,7 @@ func (c *Client) DeleteGCS(i *DeleteGCSInput) error {
 		return ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return ErrMissingVersion
 	}
 
@@ -219,7 +219,7 @@ func (c *Client) DeleteGCS(i *DeleteGCSInput) error {
 		return ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/gcs/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/gcs/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/gcs_test.go
+++ b/gcs_test.go
@@ -173,7 +173,7 @@ func TestClient_ListGCSs_validation(t *testing.T) {
 
 	_, err = testClient.ListGCSs(&ListGCSsInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -191,7 +191,7 @@ func TestClient_CreateGCS_validation(t *testing.T) {
 
 	_, err = testClient.CreateGCS(&CreateGCSInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -209,7 +209,7 @@ func TestClient_GetGCS_validation(t *testing.T) {
 
 	_, err = testClient.GetGCS(&GetGCSInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -217,7 +217,7 @@ func TestClient_GetGCS_validation(t *testing.T) {
 
 	_, err = testClient.GetGCS(&GetGCSInput{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {
@@ -236,7 +236,7 @@ func TestClient_UpdateGCS_validation(t *testing.T) {
 
 	_, err = testClient.UpdateGCS(&UpdateGCSInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -244,7 +244,7 @@ func TestClient_UpdateGCS_validation(t *testing.T) {
 
 	_, err = testClient.UpdateGCS(&UpdateGCSInput{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {
@@ -263,7 +263,7 @@ func TestClient_DeleteGCS_validation(t *testing.T) {
 
 	err = testClient.DeleteGCS(&DeleteGCSInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -271,7 +271,7 @@ func TestClient_DeleteGCS_validation(t *testing.T) {
 
 	err = testClient.DeleteGCS(&DeleteGCSInput{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {

--- a/gzip.go
+++ b/gzip.go
@@ -8,7 +8,7 @@ import (
 // Gzip represents an Gzip logging response from the Fastly API.
 type Gzip struct {
 	ServiceID string `mapstructure:"service_id"`
-	Version   string `mapstructure:"version"`
+	Version   int    `mapstructure:"version"`
 
 	Name           string `mapstructure:"name"`
 	ContentTypes   string `mapstructure:"content_types"`
@@ -32,7 +32,7 @@ type ListGzipsInput struct {
 	Service string
 
 	// Version is the specific configuration version (required).
-	Version string
+	Version int
 }
 
 // ListGzips returns the list of gzips for the configuration version.
@@ -41,11 +41,11 @@ func (c *Client) ListGzips(i *ListGzipsInput) ([]*Gzip, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/gzip", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/gzip", i.Service, i.Version)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -64,7 +64,7 @@ type CreateGzipInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	Name           string `form:"name,omitempty"`
 	ContentTypes   string `form:"content_types"`
@@ -78,11 +78,11 @@ func (c *Client) CreateGzip(i *CreateGzipInput) (*Gzip, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/gzip", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/gzip", i.Service, i.Version)
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -100,7 +100,7 @@ type GetGzipInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the Gzip to fetch.
 	Name string
@@ -112,7 +112,7 @@ func (c *Client) GetGzip(i *GetGzipInput) (*Gzip, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -120,7 +120,7 @@ func (c *Client) GetGzip(i *GetGzipInput) (*Gzip, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/gzip/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/gzip/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -138,7 +138,7 @@ type UpdateGzipInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the Gzip to update.
 	Name string
@@ -155,7 +155,7 @@ func (c *Client) UpdateGzip(i *UpdateGzipInput) (*Gzip, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -163,7 +163,7 @@ func (c *Client) UpdateGzip(i *UpdateGzipInput) (*Gzip, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/gzip/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/gzip/%s", i.Service, i.Version, i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -181,7 +181,7 @@ type DeleteGzipInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the Gzip to delete (required).
 	Name string
@@ -193,7 +193,7 @@ func (c *Client) DeleteGzip(i *DeleteGzipInput) error {
 		return ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return ErrMissingVersion
 	}
 
@@ -201,7 +201,7 @@ func (c *Client) DeleteGzip(i *DeleteGzipInput) error {
 		return ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/gzip/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/gzip/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/gzip_test.go
+++ b/gzip_test.go
@@ -156,7 +156,7 @@ func TestClient_ListGzips_validation(t *testing.T) {
 
 	_, err = testClient.ListGzips(&ListGzipsInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -174,7 +174,7 @@ func TestClient_CreateGzip_validation(t *testing.T) {
 
 	_, err = testClient.CreateGzip(&CreateGzipInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -192,7 +192,7 @@ func TestClient_GetGzip_validation(t *testing.T) {
 
 	_, err = testClient.GetGzip(&GetGzipInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -200,7 +200,7 @@ func TestClient_GetGzip_validation(t *testing.T) {
 
 	_, err = testClient.GetGzip(&GetGzipInput{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {
@@ -219,7 +219,7 @@ func TestClient_UpdateGzip_validation(t *testing.T) {
 
 	_, err = testClient.UpdateGzip(&UpdateGzipInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -227,7 +227,7 @@ func TestClient_UpdateGzip_validation(t *testing.T) {
 
 	_, err = testClient.UpdateGzip(&UpdateGzipInput{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {
@@ -246,7 +246,7 @@ func TestClient_DeleteGzip_validation(t *testing.T) {
 
 	err = testClient.DeleteGzip(&DeleteGzipInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -254,7 +254,7 @@ func TestClient_DeleteGzip_validation(t *testing.T) {
 
 	err = testClient.DeleteGzip(&DeleteGzipInput{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {

--- a/header.go
+++ b/header.go
@@ -51,7 +51,7 @@ type HeaderType string
 // Header represents a header response from the Fastly API.
 type Header struct {
 	ServiceID string `mapstructure:"service_id"`
-	Version   string `mapstructure:"version"`
+	Version   int    `mapstructure:"version"`
 
 	Name              string       `mapstructure:"name"`
 	Action            HeaderAction `mapstructure:"action"`
@@ -83,7 +83,7 @@ type ListHeadersInput struct {
 	Service string
 
 	// Version is the specific configuration version (required).
-	Version string
+	Version int
 }
 
 // ListHeaders returns the list of headers for the configuration version.
@@ -92,11 +92,11 @@ func (c *Client) ListHeaders(i *ListHeadersInput) ([]*Header, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/header", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/header", i.Service, i.Version)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -115,7 +115,7 @@ type CreateHeaderInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	Name              string       `form:"name,omitempty"`
 	Action            HeaderAction `form:"action,omitempty"`
@@ -137,11 +137,11 @@ func (c *Client) CreateHeader(i *CreateHeaderInput) (*Header, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/header", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/header", i.Service, i.Version)
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -159,7 +159,7 @@ type GetHeaderInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the header to fetch.
 	Name string
@@ -171,7 +171,7 @@ func (c *Client) GetHeader(i *GetHeaderInput) (*Header, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -179,7 +179,7 @@ func (c *Client) GetHeader(i *GetHeaderInput) (*Header, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/header/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/header/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -197,7 +197,7 @@ type UpdateHeaderInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the header to update.
 	Name string
@@ -222,7 +222,7 @@ func (c *Client) UpdateHeader(i *UpdateHeaderInput) (*Header, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -230,7 +230,7 @@ func (c *Client) UpdateHeader(i *UpdateHeaderInput) (*Header, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/header/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/header/%s", i.Service, i.Version, i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -248,7 +248,7 @@ type DeleteHeaderInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the header to delete (required).
 	Name string
@@ -260,7 +260,7 @@ func (c *Client) DeleteHeader(i *DeleteHeaderInput) error {
 		return ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return ErrMissingVersion
 	}
 
@@ -268,7 +268,7 @@ func (c *Client) DeleteHeader(i *DeleteHeaderInput) error {
 		return ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/header/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/header/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/header_test.go
+++ b/header_test.go
@@ -173,7 +173,7 @@ func TestClient_ListHeaders_validation(t *testing.T) {
 
 	_, err = testClient.ListHeaders(&ListHeadersInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -191,7 +191,7 @@ func TestClient_CreateHeader_validation(t *testing.T) {
 
 	_, err = testClient.CreateHeader(&CreateHeaderInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -209,7 +209,7 @@ func TestClient_GetHeader_validation(t *testing.T) {
 
 	_, err = testClient.GetHeader(&GetHeaderInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -217,7 +217,7 @@ func TestClient_GetHeader_validation(t *testing.T) {
 
 	_, err = testClient.GetHeader(&GetHeaderInput{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {
@@ -236,7 +236,7 @@ func TestClient_UpdateHeader_validation(t *testing.T) {
 
 	_, err = testClient.UpdateHeader(&UpdateHeaderInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -244,7 +244,7 @@ func TestClient_UpdateHeader_validation(t *testing.T) {
 
 	_, err = testClient.UpdateHeader(&UpdateHeaderInput{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {
@@ -263,7 +263,7 @@ func TestClient_DeleteHeader_validation(t *testing.T) {
 
 	err = testClient.DeleteHeader(&DeleteHeaderInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -271,7 +271,7 @@ func TestClient_DeleteHeader_validation(t *testing.T) {
 
 	err = testClient.DeleteHeader(&DeleteHeaderInput{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {

--- a/health_check.go
+++ b/health_check.go
@@ -8,7 +8,7 @@ import (
 // HealthCheck represents a health check response from the Fastly API.
 type HealthCheck struct {
 	ServiceID string `mapstructure:"service_id"`
-	Version   string `mapstructure:"version"`
+	Version   int    `mapstructure:"version"`
 
 	Name             string `mapstructure:"name"`
 	Method           string `mapstructure:"method"`
@@ -39,7 +39,7 @@ type ListHealthChecksInput struct {
 	Service string
 
 	// Version is the specific configuration version (required).
-	Version string
+	Version int
 }
 
 // ListHealthChecks returns the list of health checks for the configuration
@@ -49,11 +49,11 @@ func (c *Client) ListHealthChecks(i *ListHealthChecksInput) ([]*HealthCheck, err
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/healthcheck", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/healthcheck", i.Service, i.Version)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -72,7 +72,7 @@ type CreateHealthCheckInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	Name             string `form:"name,omitempty"`
 	Method           string `form:"method,omitempty"`
@@ -93,11 +93,11 @@ func (c *Client) CreateHealthCheck(i *CreateHealthCheckInput) (*HealthCheck, err
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/healthcheck", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/healthcheck", i.Service, i.Version)
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -115,7 +115,7 @@ type GetHealthCheckInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the health check to fetch.
 	Name string
@@ -127,7 +127,7 @@ func (c *Client) GetHealthCheck(i *GetHealthCheckInput) (*HealthCheck, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -135,7 +135,7 @@ func (c *Client) GetHealthCheck(i *GetHealthCheckInput) (*HealthCheck, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/healthcheck/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/healthcheck/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -153,7 +153,7 @@ type UpdateHealthCheckInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the health check to update.
 	Name string
@@ -177,7 +177,7 @@ func (c *Client) UpdateHealthCheck(i *UpdateHealthCheckInput) (*HealthCheck, err
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -185,7 +185,7 @@ func (c *Client) UpdateHealthCheck(i *UpdateHealthCheckInput) (*HealthCheck, err
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/healthcheck/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/healthcheck/%s", i.Service, i.Version, i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -203,7 +203,7 @@ type DeleteHealthCheckInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the health check to delete (required).
 	Name string
@@ -215,7 +215,7 @@ func (c *Client) DeleteHealthCheck(i *DeleteHealthCheckInput) error {
 		return ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return ErrMissingVersion
 	}
 
@@ -223,7 +223,7 @@ func (c *Client) DeleteHealthCheck(i *DeleteHealthCheckInput) error {
 		return ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/healthcheck/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/healthcheck/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/health_check_test.go
+++ b/health_check_test.go
@@ -187,7 +187,7 @@ func TestClient_ListHealthChecks_validation(t *testing.T) {
 
 	_, err = testClient.ListHealthChecks(&ListHealthChecksInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -205,7 +205,7 @@ func TestClient_CreateHealthCheck_validation(t *testing.T) {
 
 	_, err = testClient.CreateHealthCheck(&CreateHealthCheckInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -223,7 +223,7 @@ func TestClient_GetHealthCheck_validation(t *testing.T) {
 
 	_, err = testClient.GetHealthCheck(&GetHealthCheckInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -231,7 +231,7 @@ func TestClient_GetHealthCheck_validation(t *testing.T) {
 
 	_, err = testClient.GetHealthCheck(&GetHealthCheckInput{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {
@@ -250,7 +250,7 @@ func TestClient_UpdateHealthCheck_validation(t *testing.T) {
 
 	_, err = testClient.UpdateHealthCheck(&UpdateHealthCheckInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -258,7 +258,7 @@ func TestClient_UpdateHealthCheck_validation(t *testing.T) {
 
 	_, err = testClient.UpdateHealthCheck(&UpdateHealthCheckInput{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {
@@ -277,7 +277,7 @@ func TestClient_DeleteHealthCheck_validation(t *testing.T) {
 
 	err = testClient.DeleteHealthCheck(&DeleteHealthCheckInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -285,7 +285,7 @@ func TestClient_DeleteHealthCheck_validation(t *testing.T) {
 
 	err = testClient.DeleteHealthCheck(&DeleteHealthCheckInput{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {

--- a/logentries.go
+++ b/logentries.go
@@ -9,7 +9,7 @@ import (
 // Logentries represents a logentries response from the Fastly API.
 type Logentries struct {
 	ServiceID string `mapstructure:"service_id"`
-	Version   string `mapstructure:"version"`
+	Version   int    `mapstructure:"version"`
 
 	Name              string     `mapstructure:"name"`
 	Port              uint       `mapstructure:"port"`
@@ -38,7 +38,7 @@ type ListLogentriesInput struct {
 	Service string
 
 	// Version is the specific configuration version (required).
-	Version string
+	Version int
 }
 
 // ListLogentries returns the list of logentries for the configuration version.
@@ -47,11 +47,11 @@ func (c *Client) ListLogentries(i *ListLogentriesInput) ([]*Logentries, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/logentries", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/logentries", i.Service, i.Version)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -70,7 +70,7 @@ type CreateLogentriesInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	Name              string       `form:"name,omitempty"`
 	Port              uint         `form:"port,omitempty"`
@@ -86,11 +86,11 @@ func (c *Client) CreateLogentries(i *CreateLogentriesInput) (*Logentries, error)
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/logentries", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/logentries", i.Service, i.Version)
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -108,7 +108,7 @@ type GetLogentriesInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the logentries to fetch.
 	Name string
@@ -120,7 +120,7 @@ func (c *Client) GetLogentries(i *GetLogentriesInput) (*Logentries, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -128,7 +128,7 @@ func (c *Client) GetLogentries(i *GetLogentriesInput) (*Logentries, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/logentries/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/logentries/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -146,7 +146,7 @@ type UpdateLogentriesInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the logentries to update.
 	Name string
@@ -165,7 +165,7 @@ func (c *Client) UpdateLogentries(i *UpdateLogentriesInput) (*Logentries, error)
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -173,7 +173,7 @@ func (c *Client) UpdateLogentries(i *UpdateLogentriesInput) (*Logentries, error)
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/logentries/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/logentries/%s", i.Service, i.Version, i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -191,7 +191,7 @@ type DeleteLogentriesInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the logentries to delete (required).
 	Name string
@@ -203,7 +203,7 @@ func (c *Client) DeleteLogentries(i *DeleteLogentriesInput) error {
 		return ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return ErrMissingVersion
 	}
 
@@ -211,7 +211,7 @@ func (c *Client) DeleteLogentries(i *DeleteLogentriesInput) error {
 		return ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/logentries/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/logentries/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/logentries_test.go
+++ b/logentries_test.go
@@ -145,7 +145,7 @@ func TestClient_ListLogentries_validation(t *testing.T) {
 
 	_, err = testClient.ListLogentries(&ListLogentriesInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -163,7 +163,7 @@ func TestClient_CreateLogentries_validation(t *testing.T) {
 
 	_, err = testClient.CreateLogentries(&CreateLogentriesInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -181,7 +181,7 @@ func TestClient_GetLogentries_validation(t *testing.T) {
 
 	_, err = testClient.GetLogentries(&GetLogentriesInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -189,7 +189,7 @@ func TestClient_GetLogentries_validation(t *testing.T) {
 
 	_, err = testClient.GetLogentries(&GetLogentriesInput{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {
@@ -208,7 +208,7 @@ func TestClient_UpdateLogentries_validation(t *testing.T) {
 
 	_, err = testClient.UpdateLogentries(&UpdateLogentriesInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -216,7 +216,7 @@ func TestClient_UpdateLogentries_validation(t *testing.T) {
 
 	_, err = testClient.UpdateLogentries(&UpdateLogentriesInput{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {
@@ -235,7 +235,7 @@ func TestClient_DeleteLogentries_validation(t *testing.T) {
 
 	err = testClient.DeleteLogentries(&DeleteLogentriesInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -243,7 +243,7 @@ func TestClient_DeleteLogentries_validation(t *testing.T) {
 
 	err = testClient.DeleteLogentries(&DeleteLogentriesInput{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {

--- a/papertrail.go
+++ b/papertrail.go
@@ -9,7 +9,7 @@ import (
 // Papertrail represents a papertrail response from the Fastly API.
 type Papertrail struct {
 	ServiceID string `mapstructure:"service_id"`
-	Version   string `mapstructure:"version"`
+	Version   int    `mapstructure:"version"`
 
 	Name              string     `mapstructure:"name"`
 	Address           string     `mapstructure:"address"`
@@ -37,7 +37,7 @@ type ListPapertrailsInput struct {
 	Service string
 
 	// Version is the specific configuration version (required).
-	Version string
+	Version int
 }
 
 // ListPapertrails returns the list of papertrails for the configuration version.
@@ -46,11 +46,11 @@ func (c *Client) ListPapertrails(i *ListPapertrailsInput) ([]*Papertrail, error)
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/papertrail", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/papertrail", i.Service, i.Version)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -69,7 +69,7 @@ type CreatePapertrailInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	Name              string     `form:"name,omitempty"`
 	Address           string     `form:"address,omitempty"`
@@ -87,11 +87,11 @@ func (c *Client) CreatePapertrail(i *CreatePapertrailInput) (*Papertrail, error)
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/papertrail", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/papertrail", i.Service, i.Version)
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -109,7 +109,7 @@ type GetPapertrailInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the papertrail to fetch.
 	Name string
@@ -121,7 +121,7 @@ func (c *Client) GetPapertrail(i *GetPapertrailInput) (*Papertrail, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -129,7 +129,7 @@ func (c *Client) GetPapertrail(i *GetPapertrailInput) (*Papertrail, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/papertrail/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/papertrail/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -147,7 +147,7 @@ type UpdatePapertrailInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the papertrail to update.
 	Name string
@@ -168,7 +168,7 @@ func (c *Client) UpdatePapertrail(i *UpdatePapertrailInput) (*Papertrail, error)
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -176,7 +176,7 @@ func (c *Client) UpdatePapertrail(i *UpdatePapertrailInput) (*Papertrail, error)
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/papertrail/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/papertrail/%s", i.Service, i.Version, i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -194,7 +194,7 @@ type DeletePapertrailInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the papertrail to delete (required).
 	Name string
@@ -206,7 +206,7 @@ func (c *Client) DeletePapertrail(i *DeletePapertrailInput) error {
 		return ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return ErrMissingVersion
 	}
 
@@ -214,7 +214,7 @@ func (c *Client) DeletePapertrail(i *DeletePapertrailInput) error {
 		return ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/papertrail/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/papertrail/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/papertrail_test.go
+++ b/papertrail_test.go
@@ -138,7 +138,7 @@ func TestClient_ListPapertrails_validation(t *testing.T) {
 
 	_, err = testClient.ListPapertrails(&ListPapertrailsInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -156,7 +156,7 @@ func TestClient_CreatePapertrail_validation(t *testing.T) {
 
 	_, err = testClient.CreatePapertrail(&CreatePapertrailInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -174,7 +174,7 @@ func TestClient_GetPapertrail_validation(t *testing.T) {
 
 	_, err = testClient.GetPapertrail(&GetPapertrailInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -182,7 +182,7 @@ func TestClient_GetPapertrail_validation(t *testing.T) {
 
 	_, err = testClient.GetPapertrail(&GetPapertrailInput{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {
@@ -201,7 +201,7 @@ func TestClient_UpdatePapertrail_validation(t *testing.T) {
 
 	_, err = testClient.UpdatePapertrail(&UpdatePapertrailInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -209,7 +209,7 @@ func TestClient_UpdatePapertrail_validation(t *testing.T) {
 
 	_, err = testClient.UpdatePapertrail(&UpdatePapertrailInput{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {
@@ -228,7 +228,7 @@ func TestClient_DeletePapertrail_validation(t *testing.T) {
 
 	err = testClient.DeletePapertrail(&DeletePapertrailInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -236,7 +236,7 @@ func TestClient_DeletePapertrail_validation(t *testing.T) {
 
 	err = testClient.DeletePapertrail(&DeletePapertrailInput{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {

--- a/request_setting.go
+++ b/request_setting.go
@@ -40,7 +40,7 @@ type RequestSettingXFF string
 // RequestSetting represents a request setting response from the Fastly API.
 type RequestSetting struct {
 	ServiceID string `mapstructure:"service_id"`
-	Version   string `mapstructure:"version"`
+	Version   int    `mapstructure:"version"`
 
 	Name             string               `mapstructure:"name"`
 	ForceMiss        bool                 `mapstructure:"force_miss"`
@@ -73,7 +73,7 @@ type ListRequestSettingsInput struct {
 	Service string
 
 	// Version is the specific configuration version (required).
-	Version string
+	Version int
 }
 
 // ListRequestSettings returns the list of request settings for the
@@ -83,11 +83,11 @@ func (c *Client) ListRequestSettings(i *ListRequestSettingsInput) ([]*RequestSet
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/request_settings", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/request_settings", i.Service, i.Version)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -107,7 +107,7 @@ type CreateRequestSettingInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	Name             string               `form:"name,omitempty"`
 	ForceMiss        *Compatibool         `form:"force_miss,omitempty"`
@@ -129,11 +129,11 @@ func (c *Client) CreateRequestSetting(i *CreateRequestSettingInput) (*RequestSet
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/request_settings", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/request_settings", i.Service, i.Version)
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -151,7 +151,7 @@ type GetRequestSettingInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the request settings to fetch.
 	Name string
@@ -164,7 +164,7 @@ func (c *Client) GetRequestSetting(i *GetRequestSettingInput) (*RequestSetting, 
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -172,7 +172,7 @@ func (c *Client) GetRequestSetting(i *GetRequestSettingInput) (*RequestSetting, 
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/request_settings/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/request_settings/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -191,7 +191,7 @@ type UpdateRequestSettingInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the request settings to update.
 	Name string
@@ -216,7 +216,7 @@ func (c *Client) UpdateRequestSetting(i *UpdateRequestSettingInput) (*RequestSet
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -224,7 +224,7 @@ func (c *Client) UpdateRequestSetting(i *UpdateRequestSettingInput) (*RequestSet
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/request_settings/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/request_settings/%s", i.Service, i.Version, i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -242,7 +242,7 @@ type DeleteRequestSettingInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the request settings to delete (required).
 	Name string
@@ -254,7 +254,7 @@ func (c *Client) DeleteRequestSetting(i *DeleteRequestSettingInput) error {
 		return ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return ErrMissingVersion
 	}
 
@@ -262,7 +262,7 @@ func (c *Client) DeleteRequestSetting(i *DeleteRequestSettingInput) error {
 		return ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/request_settings/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/request_settings/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/request_setting_test.go
+++ b/request_setting_test.go
@@ -187,7 +187,7 @@ func TestClient_ListRequestSettings_validation(t *testing.T) {
 
 	_, err = testClient.ListRequestSettings(&ListRequestSettingsInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -205,7 +205,7 @@ func TestClient_CreateRequestSetting_validation(t *testing.T) {
 
 	_, err = testClient.CreateRequestSetting(&CreateRequestSettingInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -223,7 +223,7 @@ func TestClient_GetRequestSetting_validation(t *testing.T) {
 
 	_, err = testClient.GetRequestSetting(&GetRequestSettingInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -231,7 +231,7 @@ func TestClient_GetRequestSetting_validation(t *testing.T) {
 
 	_, err = testClient.GetRequestSetting(&GetRequestSettingInput{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {
@@ -250,7 +250,7 @@ func TestClient_UpdateRequestSetting_validation(t *testing.T) {
 
 	_, err = testClient.UpdateRequestSetting(&UpdateRequestSettingInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -258,7 +258,7 @@ func TestClient_UpdateRequestSetting_validation(t *testing.T) {
 
 	_, err = testClient.UpdateRequestSetting(&UpdateRequestSettingInput{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {
@@ -277,7 +277,7 @@ func TestClient_DeleteRequestSetting_validation(t *testing.T) {
 
 	err = testClient.DeleteRequestSetting(&DeleteRequestSettingInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -285,7 +285,7 @@ func TestClient_DeleteRequestSetting_validation(t *testing.T) {
 
 	err = testClient.DeleteRequestSetting(&DeleteRequestSettingInput{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {

--- a/response_object.go
+++ b/response_object.go
@@ -8,7 +8,7 @@ import (
 // ResponseObject represents a response object response from the Fastly API.
 type ResponseObject struct {
 	ServiceID string `mapstructure:"service_id"`
-	Version   string `mapstructure:"version"`
+	Version   int    `mapstructure:"version"`
 
 	Name             string `mapstructure:"name"`
 	Status           uint   `mapstructure:"status"`
@@ -36,7 +36,7 @@ type ListResponseObjectsInput struct {
 	Service string
 
 	// Version is the specific configuration version (required).
-	Version string
+	Version int
 }
 
 // ListResponseObjects returns the list of response objects for the
@@ -46,11 +46,11 @@ func (c *Client) ListResponseObjects(i *ListResponseObjectsInput) ([]*ResponseOb
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/response_object", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/response_object", i.Service, i.Version)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -70,7 +70,7 @@ type CreateResponseObjectInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	Name             string `form:"name,omitempty"`
 	Status           uint   `form:"status,omitempty"`
@@ -87,11 +87,11 @@ func (c *Client) CreateResponseObject(i *CreateResponseObjectInput) (*ResponseOb
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/response_object", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/response_object", i.Service, i.Version)
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -109,7 +109,7 @@ type GetResponseObjectInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the response object to fetch.
 	Name string
@@ -122,7 +122,7 @@ func (c *Client) GetResponseObject(i *GetResponseObjectInput) (*ResponseObject, 
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -130,7 +130,7 @@ func (c *Client) GetResponseObject(i *GetResponseObjectInput) (*ResponseObject, 
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/response_object/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/response_object/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -149,7 +149,7 @@ type UpdateResponseObjectInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the response object to update.
 	Name string
@@ -169,7 +169,7 @@ func (c *Client) UpdateResponseObject(i *UpdateResponseObjectInput) (*ResponseOb
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -177,7 +177,7 @@ func (c *Client) UpdateResponseObject(i *UpdateResponseObjectInput) (*ResponseOb
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/response_object/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/response_object/%s", i.Service, i.Version, i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -195,7 +195,7 @@ type DeleteResponseObjectInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the response object to delete (required).
 	Name string
@@ -207,7 +207,7 @@ func (c *Client) DeleteResponseObject(i *DeleteResponseObjectInput) error {
 		return ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return ErrMissingVersion
 	}
 
@@ -215,7 +215,7 @@ func (c *Client) DeleteResponseObject(i *DeleteResponseObjectInput) error {
 		return ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/response_object/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/response_object/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/response_object_test.go
+++ b/response_object_test.go
@@ -145,7 +145,7 @@ func TestClient_ListResponseObjects_validation(t *testing.T) {
 
 	_, err = testClient.ListResponseObjects(&ListResponseObjectsInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -163,7 +163,7 @@ func TestClient_CreateResponseObject_validation(t *testing.T) {
 
 	_, err = testClient.CreateResponseObject(&CreateResponseObjectInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -181,7 +181,7 @@ func TestClient_GetResponseObject_validation(t *testing.T) {
 
 	_, err = testClient.GetResponseObject(&GetResponseObjectInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -189,7 +189,7 @@ func TestClient_GetResponseObject_validation(t *testing.T) {
 
 	_, err = testClient.GetResponseObject(&GetResponseObjectInput{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {
@@ -208,7 +208,7 @@ func TestClient_UpdateResponseObject_validation(t *testing.T) {
 
 	_, err = testClient.UpdateResponseObject(&UpdateResponseObjectInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -216,7 +216,7 @@ func TestClient_UpdateResponseObject_validation(t *testing.T) {
 
 	_, err = testClient.UpdateResponseObject(&UpdateResponseObjectInput{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {
@@ -235,7 +235,7 @@ func TestClient_DeleteResponseObject_validation(t *testing.T) {
 
 	err = testClient.DeleteResponseObject(&DeleteResponseObjectInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -243,7 +243,7 @@ func TestClient_DeleteResponseObject_validation(t *testing.T) {
 
 	err = testClient.DeleteResponseObject(&DeleteResponseObjectInput{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {

--- a/s3.go
+++ b/s3.go
@@ -16,7 +16,7 @@ const (
 // S3 represents a S3 response from the Fastly API.
 type S3 struct {
 	ServiceID string `mapstructure:"service_id"`
-	Version   string `mapstructure:"version"`
+	Version   int    `mapstructure:"version"`
 
 	Name              string       `mapstructure:"name"`
 	BucketName        string       `mapstructure:"bucket_name"`
@@ -52,7 +52,7 @@ type ListS3sInput struct {
 	Service string
 
 	// Version is the specific configuration version (required).
-	Version string
+	Version int
 }
 
 // ListS3s returns the list of S3s for the configuration version.
@@ -61,11 +61,11 @@ func (c *Client) ListS3s(i *ListS3sInput) ([]*S3, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/s3", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/s3", i.Service, i.Version)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -84,7 +84,7 @@ type CreateS3Input struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	Name              string       `form:"name,omitempty"`
 	BucketName        string       `form:"bucket_name,omitempty"`
@@ -107,11 +107,11 @@ func (c *Client) CreateS3(i *CreateS3Input) (*S3, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/s3", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/s3", i.Service, i.Version)
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -129,7 +129,7 @@ type GetS3Input struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the S3 to fetch.
 	Name string
@@ -141,7 +141,7 @@ func (c *Client) GetS3(i *GetS3Input) (*S3, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -149,7 +149,7 @@ func (c *Client) GetS3(i *GetS3Input) (*S3, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/s3/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/s3/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -167,7 +167,7 @@ type UpdateS3Input struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the S3 to update.
 	Name string
@@ -193,7 +193,7 @@ func (c *Client) UpdateS3(i *UpdateS3Input) (*S3, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -201,7 +201,7 @@ func (c *Client) UpdateS3(i *UpdateS3Input) (*S3, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/s3/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/s3/%s", i.Service, i.Version, i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -219,7 +219,7 @@ type DeleteS3Input struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the S3 to delete (required).
 	Name string
@@ -231,7 +231,7 @@ func (c *Client) DeleteS3(i *DeleteS3Input) error {
 		return ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return ErrMissingVersion
 	}
 
@@ -239,7 +239,7 @@ func (c *Client) DeleteS3(i *DeleteS3Input) error {
 		return ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/s3/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/s3/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/s3_test.go
+++ b/s3_test.go
@@ -194,7 +194,7 @@ func TestClient_ListS3s_validation(t *testing.T) {
 
 	_, err = testClient.ListS3s(&ListS3sInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -212,7 +212,7 @@ func TestClient_CreateS3_validation(t *testing.T) {
 
 	_, err = testClient.CreateS3(&CreateS3Input{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -230,7 +230,7 @@ func TestClient_GetS3_validation(t *testing.T) {
 
 	_, err = testClient.GetS3(&GetS3Input{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -238,7 +238,7 @@ func TestClient_GetS3_validation(t *testing.T) {
 
 	_, err = testClient.GetS3(&GetS3Input{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {
@@ -257,7 +257,7 @@ func TestClient_UpdateS3_validation(t *testing.T) {
 
 	_, err = testClient.UpdateS3(&UpdateS3Input{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -265,7 +265,7 @@ func TestClient_UpdateS3_validation(t *testing.T) {
 
 	_, err = testClient.UpdateS3(&UpdateS3Input{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {
@@ -284,7 +284,7 @@ func TestClient_DeleteS3_validation(t *testing.T) {
 
 	err = testClient.DeleteS3(&DeleteS3Input{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -292,7 +292,7 @@ func TestClient_DeleteS3_validation(t *testing.T) {
 
 	err = testClient.DeleteS3(&DeleteS3Input{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {

--- a/service_test.go
+++ b/service_test.go
@@ -97,7 +97,7 @@ func TestClient_Services(t *testing.T) {
 	if s.Comment != nsd.Comment {
 		t.Errorf("bad comment: %q (%q)", s.Comment, nsd.Comment)
 	}
-	if nsd.Version.Number == "" {
+	if nsd.Version.Number == 0 {
 		t.Errorf("Service Detail Version is empty: (%#v)", nsd)
 	}
 

--- a/settings.go
+++ b/settings.go
@@ -5,7 +5,7 @@ import "fmt"
 // Settings represents a backend response from the Fastly API.
 type Settings struct {
 	ServiceID string `mapstructure:"service_id"`
-	Version   string `mapstructure:"version"`
+	Version   int    `mapstructure:"version"`
 
 	DefaultTTL  uint   `mapstructure:"general.default_ttl"`
 	DefaultHost string `mapstructure:"general.default_host"`
@@ -16,7 +16,7 @@ type GetSettingsInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 }
 
 // GetSettings gets the backend configuration with the given parameters.
@@ -25,11 +25,11 @@ func (c *Client) GetSettings(i *GetSettingsInput) (*Settings, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/settings", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/settings", i.Service, i.Version)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -47,7 +47,7 @@ type UpdateSettingsInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	DefaultTTL  uint   `form:"general.default_ttl"`
 	DefaultHost string `form:"general.default_host,omitempty"`
@@ -59,11 +59,11 @@ func (c *Client) UpdateSettings(i *UpdateSettingsInput) (*Settings, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/settings", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/settings", i.Service, i.Version)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err

--- a/settings_test.go
+++ b/settings_test.go
@@ -1,9 +1,9 @@
 package fastly
 
 import (
-	"testing"
 	"bytes"
 	"github.com/ajg/form"
+	"testing"
 )
 
 func TestClient_Settings(t *testing.T) {
@@ -50,7 +50,7 @@ func TestClient_Settings(t *testing.T) {
 // Tests if we can update a default_ttl to 0 as reported in issue #20
 func TestClient_UpdateSettingsInput_default_ttl(t *testing.T) {
 	t.Parallel()
-	s := UpdateSettingsInput{ Service: "foo", Version: "1", DefaultTTL: 0 }
+	s := UpdateSettingsInput{Service: "foo", Version: 1, DefaultTTL: 0}
 	buf := new(bytes.Buffer)
 	form.NewEncoder(buf).KeepZeros(true).DelimitWith('|').Encode(s)
 	if buf.String() != "Service=foo&Version=1&general.default_ttl=0" {
@@ -69,7 +69,7 @@ func TestClient_GetSettings_validation(t *testing.T) {
 
 	_, err = testClient.GetSettings(&GetSettingsInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -87,7 +87,7 @@ func TestClient_UpdateSettings_validation(t *testing.T) {
 
 	_, err = testClient.UpdateSettings(&UpdateSettingsInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)

--- a/sumologic.go
+++ b/sumologic.go
@@ -9,7 +9,7 @@ import (
 // Sumologic represents a sumologic response from the Fastly API.
 type Sumologic struct {
 	ServiceID string `mapstructure:"service_id"`
-	Version   string `mapstructure:"version"`
+	Version   int    `mapstructure:"version"`
 
 	Name              string     `mapstructure:"name"`
 	Address           string     `mapstructure:"address"`
@@ -39,7 +39,7 @@ type ListSumologicsInput struct {
 	Service string
 
 	// Version is the specific configuration version (required).
-	Version string
+	Version int
 }
 
 // ListSumologics returns the list of sumologics for the configuration version.
@@ -48,11 +48,11 @@ func (c *Client) ListSumologics(i *ListSumologicsInput) ([]*Sumologic, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/sumologic", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/sumologic", i.Service, i.Version)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -71,7 +71,7 @@ type CreateSumologicInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	Name              string `form:"name,omitempty"`
 	Address           string `form:"address,omitempty"`
@@ -88,11 +88,11 @@ func (c *Client) CreateSumologic(i *CreateSumologicInput) (*Sumologic, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/sumologic", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/sumologic", i.Service, i.Version)
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -110,7 +110,7 @@ type GetSumologicInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the sumologic to fetch.
 	Name string
@@ -122,7 +122,7 @@ func (c *Client) GetSumologic(i *GetSumologicInput) (*Sumologic, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -130,7 +130,7 @@ func (c *Client) GetSumologic(i *GetSumologicInput) (*Sumologic, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/sumologic/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/sumologic/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -148,7 +148,7 @@ type UpdateSumologicInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the sumologic to update.
 	Name string
@@ -168,7 +168,7 @@ func (c *Client) UpdateSumologic(i *UpdateSumologicInput) (*Sumologic, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -176,7 +176,7 @@ func (c *Client) UpdateSumologic(i *UpdateSumologicInput) (*Sumologic, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/sumologic/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/sumologic/%s", i.Service, i.Version, i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -194,7 +194,7 @@ type DeleteSumologicInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the sumologic to delete (required).
 	Name string
@@ -206,7 +206,7 @@ func (c *Client) DeleteSumologic(i *DeleteSumologicInput) error {
 		return ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return ErrMissingVersion
 	}
 
@@ -214,7 +214,7 @@ func (c *Client) DeleteSumologic(i *DeleteSumologicInput) error {
 		return ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/sumologic/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/sumologic/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/sumologic_test.go
+++ b/sumologic_test.go
@@ -145,7 +145,7 @@ func TestClient_ListSumologics_validation(t *testing.T) {
 
 	_, err = testClient.ListSumologics(&ListSumologicsInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -163,7 +163,7 @@ func TestClient_CreateSumologic_validation(t *testing.T) {
 
 	_, err = testClient.CreateSumologic(&CreateSumologicInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -181,7 +181,7 @@ func TestClient_GetSumologic_validation(t *testing.T) {
 
 	_, err = testClient.GetSumologic(&GetSumologicInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -189,7 +189,7 @@ func TestClient_GetSumologic_validation(t *testing.T) {
 
 	_, err = testClient.GetSumologic(&GetSumologicInput{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {
@@ -208,7 +208,7 @@ func TestClient_UpdateSumologic_validation(t *testing.T) {
 
 	_, err = testClient.UpdateSumologic(&UpdateSumologicInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -216,7 +216,7 @@ func TestClient_UpdateSumologic_validation(t *testing.T) {
 
 	_, err = testClient.UpdateSumologic(&UpdateSumologicInput{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {
@@ -235,7 +235,7 @@ func TestClient_DeleteSumologic_validation(t *testing.T) {
 
 	err = testClient.DeleteSumologic(&DeleteSumologicInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -243,7 +243,7 @@ func TestClient_DeleteSumologic_validation(t *testing.T) {
 
 	err = testClient.DeleteSumologic(&DeleteSumologicInput{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {

--- a/syslog.go
+++ b/syslog.go
@@ -9,7 +9,7 @@ import (
 // Syslog represents a syslog response from the Fastly API.
 type Syslog struct {
 	ServiceID string `mapstructure:"service_id"`
-	Version   string `mapstructure:"version"`
+	Version   int    `mapstructure:"version"`
 
 	Name              string     `mapstructure:"name"`
 	Address           string     `mapstructure:"address"`
@@ -41,7 +41,7 @@ type ListSyslogsInput struct {
 	Service string
 
 	// Version is the specific configuration version (required).
-	Version string
+	Version int
 }
 
 // ListSyslogs returns the list of syslogs for the configuration version.
@@ -50,11 +50,11 @@ func (c *Client) ListSyslogs(i *ListSyslogsInput) ([]*Syslog, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/syslog", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/syslog", i.Service, i.Version)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -73,7 +73,7 @@ type CreateSyslogInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	Name              string       `form:"name,omitempty"`
 	Address           string       `form:"address,omitempty"`
@@ -92,11 +92,11 @@ func (c *Client) CreateSyslog(i *CreateSyslogInput) (*Syslog, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/syslog", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/syslog", i.Service, i.Version)
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -114,7 +114,7 @@ type GetSyslogInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the syslog to fetch.
 	Name string
@@ -126,7 +126,7 @@ func (c *Client) GetSyslog(i *GetSyslogInput) (*Syslog, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -134,7 +134,7 @@ func (c *Client) GetSyslog(i *GetSyslogInput) (*Syslog, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/syslog/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/syslog/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -152,7 +152,7 @@ type UpdateSyslogInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the syslog to update.
 	Name string
@@ -174,7 +174,7 @@ func (c *Client) UpdateSyslog(i *UpdateSyslogInput) (*Syslog, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -182,7 +182,7 @@ func (c *Client) UpdateSyslog(i *UpdateSyslogInput) (*Syslog, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/syslog/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/syslog/%s", i.Service, i.Version, i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -200,7 +200,7 @@ type DeleteSyslogInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the syslog to delete (required).
 	Name string
@@ -212,7 +212,7 @@ func (c *Client) DeleteSyslog(i *DeleteSyslogInput) error {
 		return ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return ErrMissingVersion
 	}
 
@@ -220,7 +220,7 @@ func (c *Client) DeleteSyslog(i *DeleteSyslogInput) error {
 		return ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/syslog/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/syslog/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/syslog_test.go
+++ b/syslog_test.go
@@ -192,7 +192,7 @@ func TestClient_ListSyslogs_validation(t *testing.T) {
 
 	_, err = testClient.ListSyslogs(&ListSyslogsInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -210,7 +210,7 @@ func TestClient_CreateSyslog_validation(t *testing.T) {
 
 	_, err = testClient.CreateSyslog(&CreateSyslogInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -228,7 +228,7 @@ func TestClient_GetSyslog_validation(t *testing.T) {
 
 	_, err = testClient.GetSyslog(&GetSyslogInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -236,7 +236,7 @@ func TestClient_GetSyslog_validation(t *testing.T) {
 
 	_, err = testClient.GetSyslog(&GetSyslogInput{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {
@@ -255,7 +255,7 @@ func TestClient_UpdateSyslog_validation(t *testing.T) {
 
 	_, err = testClient.UpdateSyslog(&UpdateSyslogInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -263,7 +263,7 @@ func TestClient_UpdateSyslog_validation(t *testing.T) {
 
 	_, err = testClient.UpdateSyslog(&UpdateSyslogInput{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {
@@ -282,7 +282,7 @@ func TestClient_DeleteSyslog_validation(t *testing.T) {
 
 	err = testClient.DeleteSyslog(&DeleteSyslogInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -290,7 +290,7 @@ func TestClient_DeleteSyslog_validation(t *testing.T) {
 
 	err = testClient.DeleteSyslog(&DeleteSyslogInput{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {

--- a/vcl.go
+++ b/vcl.go
@@ -8,7 +8,7 @@ import (
 // VCL represents a response about VCL from the Fastly API.
 type VCL struct {
 	ServiceID string `mapstructure:"service_id"`
-	Version   string `mapstructure:"version"`
+	Version   int    `mapstructure:"version"`
 
 	Name    string `mapstructure:"name"`
 	Main    bool   `mapstructure:"main"`
@@ -31,7 +31,7 @@ type ListVCLsInput struct {
 	Service string
 
 	// Version is the specific configuration version (required).
-	Version string
+	Version int
 }
 
 // ListVCLs returns the list of VCLs for the configuration version.
@@ -40,11 +40,11 @@ func (c *Client) ListVCLs(i *ListVCLsInput) ([]*VCL, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/vcl", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/vcl", i.Service, i.Version)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -63,7 +63,7 @@ type GetVCLInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the VCL to fetch.
 	Name string
@@ -75,7 +75,7 @@ func (c *Client) GetVCL(i *GetVCLInput) (*VCL, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -83,7 +83,7 @@ func (c *Client) GetVCL(i *GetVCLInput) (*VCL, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/vcl/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/vcl/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -101,7 +101,7 @@ type GetGeneratedVCLInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 }
 
 // GetGeneratedVCL gets the VCL configuration with the given parameters.
@@ -110,11 +110,11 @@ func (c *Client) GetGeneratedVCL(i *GetGeneratedVCLInput) (*VCL, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/generated_vcl", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/generated_vcl", i.Service, i.Version)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -132,7 +132,7 @@ type CreateVCLInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	Name    string `form:"name,omitempty"`
 	Content string `form:"content,omitempty"`
@@ -144,11 +144,11 @@ func (c *Client) CreateVCL(i *CreateVCLInput) (*VCL, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/vcl", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/vcl", i.Service, i.Version)
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -166,7 +166,7 @@ type UpdateVCLInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the VCL to update (required).
 	Name string
@@ -181,7 +181,7 @@ func (c *Client) UpdateVCL(i *UpdateVCLInput) (*VCL, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -189,7 +189,7 @@ func (c *Client) UpdateVCL(i *UpdateVCLInput) (*VCL, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/vcl/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/vcl/%s", i.Service, i.Version, i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -207,7 +207,7 @@ type ActivateVCLInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the VCL to mark as main (required).
 	Name string
@@ -219,7 +219,7 @@ func (c *Client) ActivateVCL(i *ActivateVCLInput) (*VCL, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -227,7 +227,7 @@ func (c *Client) ActivateVCL(i *ActivateVCLInput) (*VCL, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/vcl/%s/main", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/vcl/%s/main", i.Service, i.Version, i.Name)
 	resp, err := c.Put(path, nil)
 	if err != nil {
 		return nil, err
@@ -245,7 +245,7 @@ type DeleteVCLInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the VCL to delete (required).
 	Name string
@@ -257,7 +257,7 @@ func (c *Client) DeleteVCL(i *DeleteVCLInput) error {
 		return ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return ErrMissingVersion
 	}
 
@@ -265,7 +265,7 @@ func (c *Client) DeleteVCL(i *DeleteVCLInput) error {
 		return ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/vcl/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/vcl/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/vcl_test.go
+++ b/vcl_test.go
@@ -157,7 +157,7 @@ func TestClient_ListVCLs_validation(t *testing.T) {
 
 	_, err = testClient.ListVCLs(&ListVCLsInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -175,7 +175,7 @@ func TestClient_CreateVCL_validation(t *testing.T) {
 
 	_, err = testClient.CreateVCL(&CreateVCLInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -193,7 +193,7 @@ func TestClient_GetVCL_validation(t *testing.T) {
 
 	_, err = testClient.GetVCL(&GetVCLInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -201,7 +201,7 @@ func TestClient_GetVCL_validation(t *testing.T) {
 
 	_, err = testClient.GetVCL(&GetVCLInput{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {
@@ -220,7 +220,7 @@ func TestClient_UpdateVCL_validation(t *testing.T) {
 
 	_, err = testClient.UpdateVCL(&UpdateVCLInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -228,7 +228,7 @@ func TestClient_UpdateVCL_validation(t *testing.T) {
 
 	_, err = testClient.UpdateVCL(&UpdateVCLInput{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {
@@ -247,7 +247,7 @@ func TestClient_ActivateVCL_validation(t *testing.T) {
 
 	_, err = testClient.ActivateVCL(&ActivateVCLInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -255,7 +255,7 @@ func TestClient_ActivateVCL_validation(t *testing.T) {
 
 	_, err = testClient.ActivateVCL(&ActivateVCLInput{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {
@@ -274,7 +274,7 @@ func TestClient_DeleteVCL_validation(t *testing.T) {
 
 	err = testClient.DeleteVCL(&DeleteVCLInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -282,7 +282,7 @@ func TestClient_DeleteVCL_validation(t *testing.T) {
 
 	err = testClient.DeleteVCL(&DeleteVCLInput{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {

--- a/version.go
+++ b/version.go
@@ -7,14 +7,14 @@ import (
 
 // Version represents a distinct configuration version.
 type Version struct {
-	Number    string     `mapstructure:"number"`
-	Comment   string     `mapstructure:"comment"`
-	ServiceID string     `mapstructure:"service_id"`
-	Active    bool       `mapstructure:"active"`
-	Locked    bool       `mapstructure:"locked"`
-	Deployed  bool       `mapstructure:"deployed"`
-	Staging   bool       `mapstructure:"staging"`
-	Testing   bool       `mapstructure:"testing"`
+	Number    int    `mapstructure:"number"`
+	Comment   string `mapstructure:"comment"`
+	ServiceID string `mapstructure:"service_id"`
+	Active    bool   `mapstructure:"active"`
+	Locked    bool   `mapstructure:"locked"`
+	Deployed  bool   `mapstructure:"deployed"`
+	Staging   bool   `mapstructure:"staging"`
+	Testing   bool   `mapstructure:"testing"`
 }
 
 // versionsByNumber is a sortable list of versions. This is used by the version
@@ -114,7 +114,7 @@ type GetVersionInput struct {
 	Service string
 
 	// Version is the version number to fetch (required).
-	Version string
+	Version int
 }
 
 // GetVersion fetches a version with the given information.
@@ -123,11 +123,11 @@ func (c *Client) GetVersion(i *GetVersionInput) (*Version, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d", i.Service, i.Version)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -145,7 +145,7 @@ type UpdateVersionInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	Comment string `form:"comment,omitempty"`
 }
@@ -156,11 +156,11 @@ func (c *Client) UpdateVersion(i *UpdateVersionInput) (*Version, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d", i.Service, i.Version)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -178,7 +178,7 @@ type ActivateVersionInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 }
 
 // ActivateVersion activates the given version.
@@ -187,11 +187,11 @@ func (c *Client) ActivateVersion(i *ActivateVersionInput) (*Version, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/activate", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/activate", i.Service, i.Version)
 	resp, err := c.Put(path, nil)
 	if err != nil {
 		return nil, err
@@ -209,7 +209,7 @@ type DeactivateVersionInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 }
 
 // DeactivateVersion deactivates the given version.
@@ -218,11 +218,11 @@ func (c *Client) DeactivateVersion(i *DeactivateVersionInput) (*Version, error) 
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/deactivate", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/deactivate", i.Service, i.Version)
 	resp, err := c.Put(path, nil)
 	if err != nil {
 		return nil, err
@@ -240,7 +240,7 @@ type CloneVersionInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 }
 
 // CloneVersion creates a clone of the version with and returns a new
@@ -251,11 +251,11 @@ func (c *Client) CloneVersion(i *CloneVersionInput) (*Version, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/clone", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/clone", i.Service, i.Version)
 	resp, err := c.Put(path, nil)
 	if err != nil {
 		return nil, err
@@ -273,7 +273,7 @@ type ValidateVersionInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 }
 
 // ValidateVersion validates if the given version is okay.
@@ -284,11 +284,11 @@ func (c *Client) ValidateVersion(i *ValidateVersionInput) (bool, string, error) 
 		return false, msg, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return false, msg, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/validate", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/validate", i.Service, i.Version)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return false, msg, err
@@ -308,7 +308,7 @@ type LockVersionInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 }
 
 // LockVersion locks the specified version.
@@ -317,11 +317,11 @@ func (c *Client) LockVersion(i *LockVersionInput) (*Version, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/lock", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/lock", i.Service, i.Version)
 	resp, err := c.Put(path, nil)
 	if err != nil {
 		return nil, err

--- a/version_test.go
+++ b/version_test.go
@@ -1,6 +1,9 @@
 package fastly
 
-import "testing"
+import (
+	"sort"
+	"testing"
+)
 
 func TestClient_Versions(t *testing.T) {
 	t.Parallel()
@@ -20,7 +23,7 @@ func TestClient_Versions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if v.Number == "" {
+	if v.Number == 0 {
 		t.Errorf("bad number: %q", v.Number)
 	}
 
@@ -52,7 +55,7 @@ func TestClient_Versions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if nv.Number == "" {
+	if nv.Number == 0 {
 		t.Errorf("bad number: %q", nv.Number)
 	}
 
@@ -103,6 +106,20 @@ func TestClient_Versions(t *testing.T) {
 	}
 }
 
+func TestClient_SortVersions(t *testing.T) {
+	versionsData := []*Version{
+		&Version{Number: 1},
+		&Version{Number: 201},
+		&Version{Number: 10},
+		&Version{Number: 2},
+		&Version{Number: 197},
+	}
+	sort.Sort(versionsByNumber(versionsData))
+	if versionsData[0].Number != 1 || versionsData[1].Number != 2 || versionsData[2].Number != 10 || versionsData[3].Number != 197 || versionsData[4].Number != 201 {
+		t.Fatalf("The sort.Sort did not work properly. Got: %s\n", versionsData)
+	}
+}
+
 func TestClient_ListVersions_validation(t *testing.T) {
 	var err error
 	_, err = testClient.ListVersions(&ListVersionsInput{
@@ -134,7 +151,7 @@ func TestClient_GetVersion_validation(t *testing.T) {
 
 	_, err = testClient.GetVersion(&GetVersionInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -152,7 +169,7 @@ func TestClient_UpdateVersion_validation(t *testing.T) {
 
 	_, err = testClient.UpdateVersion(&UpdateVersionInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -170,7 +187,7 @@ func TestClient_ActivateVersion_validation(t *testing.T) {
 
 	_, err = testClient.ActivateVersion(&ActivateVersionInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -188,7 +205,7 @@ func TestClient_DeactivateVersion_validation(t *testing.T) {
 
 	_, err = testClient.DeactivateVersion(&DeactivateVersionInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -206,7 +223,7 @@ func TestClient_CloneVersion_validation(t *testing.T) {
 
 	_, err = testClient.CloneVersion(&CloneVersionInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -224,7 +241,7 @@ func TestClient_ValidateVersion_validation(t *testing.T) {
 
 	_, _, err = testClient.ValidateVersion(&ValidateVersionInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -242,7 +259,7 @@ func TestClient_LockVersion_validation(t *testing.T) {
 
 	_, err = testClient.LockVersion(&LockVersionInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)

--- a/wordpress.go
+++ b/wordpress.go
@@ -8,7 +8,7 @@ import (
 // Wordpress represents a wordpress response from the Fastly API.
 type Wordpress struct {
 	ServiceID string `mapstructure:"service_id"`
-	Version   string `mapstructure:"version"`
+	Version   int    `mapstructure:"version"`
 
 	Name    string `mapstructure:"name"`
 	Path    string `mapstructure:"path"`
@@ -30,7 +30,7 @@ type ListWordpressesInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 }
 
 // ListWordpresses returns the list of wordpresses for the configuration version.
@@ -39,11 +39,11 @@ func (c *Client) ListWordpresses(i *ListWordpressesInput) ([]*Wordpress, error) 
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/wordpress", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/wordpress", i.Service, i.Version)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -62,7 +62,7 @@ type CreateWordpressInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	Name    string `form:"name,omitempty"`
 	Path    string `form:"path,omitempty"`
@@ -75,11 +75,11 @@ func (c *Client) CreateWordpress(i *CreateWordpressInput) (*Wordpress, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/wordpress", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/wordpress", i.Service, i.Version)
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -97,7 +97,7 @@ type GetWordpressInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the wordpress to fetch.
 	Name string
@@ -109,7 +109,7 @@ func (c *Client) GetWordpress(i *GetWordpressInput) (*Wordpress, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -117,7 +117,7 @@ func (c *Client) GetWordpress(i *GetWordpressInput) (*Wordpress, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/wordpress/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/wordpress/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -135,7 +135,7 @@ type UpdateWordpressInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the wordpress to update.
 	Name string
@@ -151,7 +151,7 @@ func (c *Client) UpdateWordpress(i *UpdateWordpressInput) (*Wordpress, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -159,7 +159,7 @@ func (c *Client) UpdateWordpress(i *UpdateWordpressInput) (*Wordpress, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/wordpress/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/wordpress/%s", i.Service, i.Version, i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -177,7 +177,7 @@ type DeleteWordpressInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the wordpress to delete (required).
 	Name string
@@ -189,7 +189,7 @@ func (c *Client) DeleteWordpress(i *DeleteWordpressInput) error {
 		return ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return ErrMissingVersion
 	}
 
@@ -197,7 +197,7 @@ func (c *Client) DeleteWordpress(i *DeleteWordpressInput) error {
 		return ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/wordpress/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/wordpress/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/wordpress_test.go
+++ b/wordpress_test.go
@@ -131,7 +131,7 @@ func TestClient_ListWordpresses_validation(t *testing.T) {
 
 	_, err = testClient.ListWordpresses(&ListWordpressesInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -149,7 +149,7 @@ func TestClient_CreateWordpress_validation(t *testing.T) {
 
 	_, err = testClient.CreateWordpress(&CreateWordpressInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -167,7 +167,7 @@ func TestClient_GetWordpress_validation(t *testing.T) {
 
 	_, err = testClient.GetWordpress(&GetWordpressInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -175,7 +175,7 @@ func TestClient_GetWordpress_validation(t *testing.T) {
 
 	_, err = testClient.GetWordpress(&GetWordpressInput{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {
@@ -194,7 +194,7 @@ func TestClient_UpdateWordpress_validation(t *testing.T) {
 
 	_, err = testClient.UpdateWordpress(&UpdateWordpressInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -202,7 +202,7 @@ func TestClient_UpdateWordpress_validation(t *testing.T) {
 
 	_, err = testClient.UpdateWordpress(&UpdateWordpressInput{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {
@@ -221,7 +221,7 @@ func TestClient_DeleteWordpress_validation(t *testing.T) {
 
 	err = testClient.DeleteWordpress(&DeleteWordpressInput{
 		Service: "foo",
-		Version: "",
+		Version: 0,
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -229,7 +229,7 @@ func TestClient_DeleteWordpress_validation(t *testing.T) {
 
 	err = testClient.DeleteWordpress(&DeleteWordpressInput{
 		Service: "foo",
-		Version: "1",
+		Version: 1,
 		Name:    "",
 	})
 	if err != ErrMissingName {


### PR DESCRIPTION
Currently the sorting of the versions is based on the sorting of literal fields type.
In a literal sorting, 400 is smaller than 9 for example.
This is what's causing the issue #36.
This PR adds a test showing it and the tests fixing it.