### PR TITLE
Add message_type support for s3logging

### DIFF
--- a/fixtures/s3s/create.yaml
+++ b/fixtures/s3s/create.yaml
@@ -33,6 +33,8 @@ interactions:
       - secret_key
       timestamp_format:
       - '%Y'
+      message_type:
+      - "blank"
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
@@ -43,7 +45,7 @@ interactions:
     url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/657/logging/s3
     method: POST
   response:
-    body: '{"access_key":"access_key","bucket_name":"bucket-name","domain":"s3-website-us-west-2.amazonaws.com","format":"format","format_version":"2","gzip_level":"9","name":"test-s3","path":"/path","period":"12","redundancy":"reduced_redundancy","secret_key":"secret_key","timestamp_format":"%Y","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":"657","placement":null,"response_condition":"","server_side_encryption_kms_key_id":null,"public_key":null,"updated_at":"2017-04-17T16:00:59+00:00","message_type":"classic","server_side_encryption":null,"deleted_at":null,"created_at":"2017-04-17T16:00:59+00:00"}'
+    body: '{"access_key":"access_key","bucket_name":"bucket-name","domain":"s3-website-us-west-2.amazonaws.com","format":"format","format_version":"2","gzip_level":"9","name":"test-s3","path":"/path","period":"12","redundancy":"reduced_redundancy","secret_key":"secret_key","timestamp_format":"%Y","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":"657","placement":null,"response_condition":"","server_side_encryption_kms_key_id":null,"public_key":null,"updated_at":"2017-04-17T16:00:59+00:00","message_type":"blank","server_side_encryption":null,"deleted_at":null,"created_at":"2017-04-17T16:00:59+00:00"}'
     headers:
       Accept-Ranges:
       - bytes

--- a/s3.go
+++ b/s3.go
@@ -29,6 +29,7 @@ type S3 struct {
 	Format            string       `mapstructure:"format"`
 	FormatVersion     uint         `mapstructure:"format_version"`
 	ResponseCondition string       `mapstructure:"response_condition"`
+	MessageType       string       `mapstructure:"message_type"`
 	TimestampFormat   string       `mapstructure:"timestamp_format"`
 	Redundancy        S3Redundancy `mapstructure:"redundancy"`
 	CreatedAt         *time.Time   `mapstructure:"created_at"`
@@ -95,6 +96,7 @@ type CreateS3Input struct {
 	Period            uint         `form:"period,omitempty"`
 	GzipLevel         uint         `form:"gzip_level,omitempty"`
 	Format            string       `form:"format,omitempty"`
+	MessageType       string       `form:"message_type,omitempty"`
 	FormatVersion     uint         `form:"format_version,omitempty"`
 	ResponseCondition string       `form:"response_condition,omitempty"`
 	TimestampFormat   string       `form:"timestamp_format,omitempty"`
@@ -183,6 +185,7 @@ type UpdateS3Input struct {
 	Format            string       `form:"format,omitempty"`
 	FormatVersion     uint         `form:"format_version,omitempty"`
 	ResponseCondition string       `form:"response_condition,omitempty"`
+	MessageType       string       `form:"message_type,omitempty"`
 	TimestampFormat   string       `form:"timestamp_format,omitempty"`
 	Redundancy        S3Redundancy `form:"redundancy,omitempty"`
 }

--- a/s3_test.go
+++ b/s3_test.go
@@ -88,6 +88,9 @@ func TestClient_S3s(t *testing.T) {
 	if s3.Redundancy != S3RedundancyReduced {
 		t.Errorf("bad redundancy: %q", s3.Redundancy)
 	}
+	if s3.MessageType != "blank" {
+		t.Errorf("bad message_type: %q", s3.MessageType)
+	}
 
 	// List
 	var s3s []*S3


### PR DESCRIPTION
We'd like to be able to set message_type parameter on s3logging Fastly property.

Potential use case for this is eg. being able to set message_type to `blank` and use `format` to write logs to s3 as a JSON payload (we can use `format` to build JSON structured logs).

Most of the tests already included `message_type` in response body, but it wasn't being parsed.