### PR TITLE
Add support for ACLs and ACL entries

### DIFF
--- a/acl.go
+++ b/acl.go
@@ -1,0 +1,216 @@
+package fastly
+
+import (
+	"fmt"
+	"sort"
+)
+
+type Acl struct {
+	ServiceID string `mapstructure:"service_id"`
+	Version   int    `mapstructure:"version"`
+
+	Name string `mapstructure:"name"`
+	ID   string `mapstructure:"id"`
+}
+
+// aclsByName is a sortable list of ACLs.
+type aclsByName []*Acl
+
+// Len, Swap, and Less implement the sortable interface.
+func (s aclsByName) Len() int      { return len(s) }
+func (s aclsByName) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+func (s aclsByName) Less(i, j int) bool {
+	return s[i].Name < s[j].Name
+}
+
+// ListAclsInput is used as input to the ListAcls function.
+type ListAclsInput struct {
+	// Service is the ID of the service (required).
+	Service string
+
+	// Version is the specific configuration version (required).
+	Version int
+}
+
+// ListAcls returns the list of ACLs for the configuration version.
+func (c *Client) ListAcls(i *ListAclsInput) ([]*Acl, error) {
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
+
+	if i.Version == 0 {
+		return nil, ErrMissingVersion
+	}
+
+	path := fmt.Sprintf("/service/%s/version/%d/acl", i.Service, i.Version)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var as []*Acl
+	if err := decodeJSON(&as, resp.Body); err != nil {
+		return nil, err
+	}
+	sort.Stable(aclsByName(as))
+	return as, nil
+}
+
+// CreateAclInput is used as input to the CreateAcl function.
+type CreateAclInput struct {
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version int
+
+	// Name is the name of the ACL to create (required)
+	Name string `form:"name"`
+}
+
+func (c *Client) CreateAcl(i *CreateAclInput) (*Acl, error) {
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
+
+	if i.Version == 0 {
+		return nil, ErrMissingVersion
+	}
+
+	path := fmt.Sprintf("/service/%s/version/%d/acl", i.Service, i.Version)
+	resp, err := c.PostForm(path, i, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var a *Acl
+	if err := decodeJSON(&a, resp.Body); err != nil {
+		return nil, err
+	}
+	return a, nil
+}
+
+// DeleteAclInput is the input parameter to DeleteAcl function.
+type DeleteAclInput struct {
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version int
+
+	// Name is the name of the acl to delete (required).
+	Name string
+}
+
+// DeleteAcl deletes the given acl version.
+func (c *Client) DeleteAcl(i *DeleteAclInput) error {
+	if i.Service == "" {
+		return ErrMissingService
+	}
+
+	if i.Version == 0 {
+		return ErrMissingVersion
+	}
+
+	if i.Name == "" {
+		return ErrMissingName
+	}
+
+	path := fmt.Sprintf("/service/%s/version/%d/acl/%s", i.Service, i.Version, i.Name)
+	resp, err := c.Delete(path, nil)
+	if err != nil {
+		return err
+	}
+
+	var r *statusResp
+	if err := decodeJSON(&r, resp.Body); err != nil {
+		return err
+	}
+	if !r.Ok() {
+		return fmt.Errorf("Not Ok")
+	}
+	return nil
+}
+
+// GetAclInput is the input parameter to GetAcl function.
+type GetAclInput struct {
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version int
+
+	// Name is the name of the acl to get (required).
+	Name string
+}
+
+// GetAcl gets the ACL configuration with the given parameters.
+func (c *Client) GetAcl(i *GetAclInput) (*Acl, error) {
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
+
+	if i.Version == 0 {
+		return nil, ErrMissingVersion
+	}
+
+	if i.Name == "" {
+		return nil, ErrMissingName
+	}
+
+	path := fmt.Sprintf("/service/%s/version/%d/acl/%s", i.Service, i.Version, i.Name)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var a *Acl
+	if err := decodeJSON(&a, resp.Body); err != nil {
+		return nil, err
+	}
+	return a, nil
+}
+
+// UpdateAclInput is the input parameter to UpdateAcl function.
+type UpdateAclInput struct {
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version int
+
+	// Name is the name of the acl to update (required).
+	Name string
+
+	// NewName is the new name of the acl to update (required).
+	NewName string `form:"name"`
+}
+
+// UpdateAcl updates the name of the ACL with the given parameters.
+func (c *Client) UpdateAcl(i *UpdateAclInput) (*Acl, error) {
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
+
+	if i.Version == 0 {
+		return nil, ErrMissingVersion
+	}
+
+	if i.Name == "" {
+		return nil, ErrMissingName
+	}
+
+	if i.NewName == "" {
+		return nil, ErrMissingNewName
+	}
+
+	path := fmt.Sprintf("/service/%s/version/%d/acl/%s", i.Service, i.Version, i.Name)
+	resp, err := c.PutForm(path, i, nil)
+
+	if err != nil {
+		return nil, err
+	}
+
+	var a *Acl
+	if err := decodeJSON(&a, resp.Body); err != nil {
+		return nil, err
+	}
+
+	return a, nil
+}

--- a/acl_entry.go
+++ b/acl_entry.go
@@ -1,0 +1,222 @@
+package fastly
+
+import (
+	"fmt"
+	"sort"
+)
+
+type AclEntry struct {
+	ServiceID string `mapstructure:"service_id"`
+	AclID     string `mapstructure:"acl_id"`
+
+	ID      string `mapstructure:"id"`
+	IP      string `mapstructure:"ip"`
+	Subnet  string `mapstructure:"subnet"`
+	Negated bool   `mapstructure:"negated"`
+	Comment string `mapstructure:"comment"`
+}
+
+// entriesById is a sortable list of Acl entries.
+type entriesById []*AclEntry
+
+// Len, Swap, and Less implements the sortable interface.
+func (s entriesById) Len() int      { return len(s) }
+func (s entriesById) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+func (s entriesById) Less(i, j int) bool {
+	return s[i].ID < s[j].ID
+}
+
+// ListAclEntriesInput is the input parameter to ListAclEntries function.
+type ListAclEntriesInput struct {
+	Service string
+	Acl     string
+}
+
+// ListAclEntries return a list of entries for an Acl
+func (c *Client) ListAclEntries(i *ListAclEntriesInput) ([]*AclEntry, error) {
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
+
+	if i.Acl == "" {
+		return nil, ErrMissingAcl
+	}
+
+	path := fmt.Sprintf("/service/%s/acl/%s/entries", i.Service, i.Acl)
+
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var es []*AclEntry
+	if err := decodeJSON(&es, resp.Body); err != nil {
+		return nil, err
+	}
+
+	sort.Stable(entriesById(es))
+
+	return es, nil
+}
+
+// GetAclEntryInput is the input parameter to GetAclEntry function.
+type GetAclEntryInput struct {
+	Service string
+	Acl     string
+	ID      string
+}
+
+// GetAclEntry returns a single Acl entry based on its ID.
+func (c *Client) GetAclEntry(i *GetAclEntryInput) (*AclEntry, error) {
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
+
+	if i.Acl == "" {
+		return nil, ErrMissingAcl
+	}
+
+	if i.ID == "" {
+		return nil, ErrMissingID
+	}
+
+	path := fmt.Sprintf("/service/%s/acl/%s/entry/%s", i.Service, i.Acl, i.ID)
+
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var e *AclEntry
+	if err := decodeJSON(&e, resp.Body); err != nil {
+		return nil, err
+	}
+
+	return e, nil
+}
+
+// CreateAclEntryInput the input parameter to CreateAclEntry function.
+type CreateAclEntryInput struct {
+	// Required fields
+	Service string
+	Acl     string
+	IP      string `form:"ip"`
+
+	// Optional fields
+	Subnet  string `form:"subnet,omitempty"`
+	Negated bool   `form:"negated,omitempty"`
+	Comment string `form:"comment,omitempty"`
+}
+
+// CreateAclEntry creates and returns a new Acl entry.
+func (c *Client) CreateAclEntry(i *CreateAclEntryInput) (*AclEntry, error) {
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
+
+	if i.Acl == "" {
+		return nil, ErrMissingAcl
+	}
+
+	if i.IP == "" {
+		return nil, ErrMissingIP
+	}
+
+	path := fmt.Sprintf("/service/%s/acl/%s/entry", i.Service, i.Acl)
+
+	resp, err := c.PostForm(path, i, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var e *AclEntry
+	if err := decodeJSON(&e, resp.Body); err != nil {
+		return nil, err
+	}
+
+	return e, nil
+}
+
+// DeleteAclEntryInput the input parameter to DeleteAclEntry function.
+type DeleteAclEntryInput struct {
+	Service string
+	Acl     string
+	ID      string
+}
+
+// DeleteAclEntry deletes an entry from an Acl based on its ID
+func (c *Client) DeleteAclEntry(i *DeleteAclEntryInput) error {
+	if i.Service == "" {
+		return ErrMissingService
+	}
+
+	if i.Acl == "" {
+		return ErrMissingAcl
+	}
+
+	if i.ID == "" {
+		return ErrMissingID
+	}
+
+	path := fmt.Sprintf("/service/%s/acl/%s/entry/%s", i.Service, i.Acl, i.ID)
+
+	resp, err := c.Delete(path, nil)
+	if err != nil {
+		return err
+	}
+
+	var r *statusResp
+	if err := decodeJSON(&r, resp.Body); err != nil {
+		return err
+	}
+
+	if !r.Ok() {
+		return fmt.Errorf("Not OK")
+	}
+
+	return nil
+
+}
+
+// UpdateAclEntryInput is the input parameter to UpdateAclEntry function.
+type UpdateAclEntryInput struct {
+	// Required fields
+	Service string
+	Acl     string
+	ID      string
+
+	// Optional fields
+	IP      string `form:"ip,omitempty"`
+	Subnet  string `form:"subnet,omitempty"`
+	Negated bool   `form:"negated,omitempty"`
+	Comment string `form:"comment,omitempty"`
+}
+
+// UpdateAclEntry updates an Acl entry
+func (c *Client) UpdateAclEntry(i *UpdateAclEntryInput) (*AclEntry, error) {
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
+
+	if i.Acl == "" {
+		return nil, ErrMissingAcl
+	}
+
+	if i.ID == "" {
+		return nil, ErrMissingID
+	}
+
+	path := fmt.Sprintf("/service/%s/acl/%s/entry/%s", i.Service, i.Acl, i.ID)
+
+	resp, err := c.RequestForm("PATCH", path, i, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var e *AclEntry
+	if err := decodeJSON(&e, resp.Body); err != nil {
+		return nil, err
+	}
+
+	return e, nil
+}

--- a/acl_entry_test.go
+++ b/acl_entry_test.go
@@ -1,0 +1,270 @@
+package fastly
+
+import "testing"
+
+func TestClient_AclEntries(t *testing.T) {
+
+	var err error
+	var tv *Version
+	record(t, "acls/version", func(c *Client) {
+		tv = testVersion(t, c)
+	})
+
+	// Create ACL before adding entries to it
+	var a *Acl
+	record(t, "acl_entries/create_acl", func(c *Client) {
+		a, err = c.CreateAcl(&CreateAclInput{
+			Service: testServiceID,
+			Version: tv.Number,
+			Name:    "entry_acl",
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Clean up helper Acl
+	defer func() {
+		record(t, "acl_entries/cleanup", func(c *Client) {
+			err = c.DeleteAcl(&DeleteAclInput{
+				Service: testServiceID,
+				Version: tv.Number,
+				Name:    "entry_acl",
+			})
+		})
+	}()
+
+	// Create
+	var e *AclEntry
+	record(t, "acl_entries/create", func(c *Client) {
+		e, err = c.CreateAclEntry(&CreateAclEntryInput{
+			Service: testServiceID,
+			Acl:     a.ID,
+			IP:      "10.0.0.3",
+			Subnet:  "8",
+			Negated: false,
+			Comment: "test entry",
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if e.IP != "10.0.0.3" {
+		t.Errorf("bad IP: %q", e.IP)
+	}
+
+	if e.Subnet != "8" {
+		t.Errorf("Bad subnet: %q", e.Subnet)
+	}
+
+	if e.Negated != false {
+		t.Errorf("Bad negated flag: %q", e.Negated)
+	}
+
+	if e.Comment != "test entry" {
+		t.Errorf("Bad comment: %q", e.Comment)
+	}
+
+	// List
+	var es []*AclEntry
+	record(t, "acl_entries/list", func(c *Client) {
+		es, err = c.ListAclEntries(&ListAclEntriesInput{
+			Service: testServiceID,
+			Acl:     a.ID,
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(es) != 1 {
+		t.Errorf("Bad entries: %v", es)
+	}
+
+	// Get
+	var ne *AclEntry
+	record(t, "acl_entries/get", func(c *Client) {
+		ne, err = c.GetAclEntry(&GetAclEntryInput{
+			Service: testServiceID,
+			Acl:     a.ID,
+			ID:      e.ID,
+		})
+	})
+
+	if e.IP != ne.IP {
+		t.Errorf("bad IP: %v", ne.IP)
+	}
+
+	if e.Subnet != ne.Subnet {
+		t.Errorf("bad subnet: %v", ne.Subnet)
+	}
+
+	if e.Negated != ne.Negated {
+		t.Errorf("bad Negated flag: %v", ne.Negated)
+	}
+
+	if e.Comment != ne.Comment {
+		t.Errorf("bad comment: %v", ne.Comment)
+	}
+
+	// Update
+	var ue *AclEntry
+	record(t, "acl_entries/update", func(c *Client) {
+		ue, err = c.UpdateAclEntry(&UpdateAclEntryInput{
+			Service: testServiceID,
+			Acl:     a.ID,
+			ID:      e.ID,
+			IP:      "10.0.0.4",
+			Negated: true,
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if ue.IP != "10.0.0.4" {
+		t.Errorf("bad IP: %q", ue.IP)
+	}
+	if e.Subnet != ue.Subnet {
+		t.Errorf("bad subnet: %v", ne.Subnet)
+	}
+
+	if ue.Negated != true {
+		t.Errorf("bad Negated flag: %v", ne.Negated)
+	}
+
+	if e.Comment != ue.Comment {
+		t.Errorf("bad comment: %v", ne.Comment)
+	}
+
+	// Delete
+	record(t, "acl_entries/delete", func(c *Client) {
+		err = c.DeleteAclEntry(&DeleteAclEntryInput{
+			Service: testServiceID,
+			Acl:     a.ID,
+			ID:      e.ID,
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+}
+
+func TestClient_ListAclEntries_validation(t *testing.T) {
+	var err error
+	_, err = testClient.ListAclEntries(&ListAclEntriesInput{
+		Service: "",
+	})
+	if err != ErrMissingService {
+		t.Errorf("bad error: %s", err)
+	}
+
+	_, err = testClient.ListAclEntries(&ListAclEntriesInput{
+		Service: "foo",
+		Acl:     "",
+	})
+	if err != ErrMissingAcl {
+		t.Errorf("bad error: %s", err)
+	}
+}
+
+func TestClient_CreateAclEntry_validation(t *testing.T) {
+	var err error
+	_, err = testClient.CreateAclEntry(&CreateAclEntryInput{
+		Service: "",
+	})
+	if err != ErrMissingService {
+		t.Errorf("bad error: %s", err)
+	}
+
+	_, err = testClient.CreateAclEntry(&CreateAclEntryInput{
+		Service: "foo",
+		Acl:     "",
+	})
+	if err != ErrMissingAcl {
+		t.Errorf("bad error: %s", err)
+	}
+}
+
+func TestClient_GetAclEntry_validation(t *testing.T) {
+	var err error
+	_, err = testClient.GetAclEntry(&GetAclEntryInput{
+		Service: "",
+	})
+	if err != ErrMissingService {
+		t.Errorf("bad error: %s", err)
+	}
+
+	_, err = testClient.GetAclEntry(&GetAclEntryInput{
+		Service: "foo",
+		Acl:     "",
+	})
+	if err != ErrMissingAcl {
+		t.Errorf("bad error: %s", err)
+	}
+
+	_, err = testClient.GetAclEntry(&GetAclEntryInput{
+		Service: "foo",
+		Acl:     "acl",
+		ID:      "",
+	})
+	if err != ErrMissingID {
+		t.Errorf("bad error: %s", err)
+	}
+}
+
+func TestClient_UpdateAclEntry_validation(t *testing.T) {
+	var err error
+	_, err = testClient.UpdateAclEntry(&UpdateAclEntryInput{
+		Service: "",
+	})
+	if err != ErrMissingService {
+		t.Errorf("bad error: %s", err)
+	}
+
+	_, err = testClient.UpdateAclEntry(&UpdateAclEntryInput{
+		Service: "foo",
+		Acl:     "",
+	})
+	if err != ErrMissingAcl {
+		t.Errorf("bad error: %s", err)
+	}
+
+	_, err = testClient.UpdateAclEntry(&UpdateAclEntryInput{
+		Service: "foo",
+		Acl:     "acl",
+		ID:      "",
+	})
+	if err != ErrMissingID {
+		t.Errorf("bad error: %s", err)
+	}
+}
+
+func TestClient_DeleteAclEntry_validation(t *testing.T) {
+	var err error
+	err = testClient.DeleteAclEntry(&DeleteAclEntryInput{
+		Service: "",
+	})
+	if err != ErrMissingService {
+		t.Errorf("bad error: %s", err)
+	}
+
+	err = testClient.DeleteAclEntry(&DeleteAclEntryInput{
+		Service: "foo",
+		Acl:     "",
+	})
+	if err != ErrMissingAcl {
+		t.Errorf("bad error: %s", err)
+	}
+
+	err = testClient.DeleteAclEntry(&DeleteAclEntryInput{
+		Service: "foo",
+		Acl:     "acl",
+		ID:      "",
+	})
+	if err != ErrMissingID {
+		t.Errorf("bad error: %s", err)
+	}
+}

--- a/acl_test.go
+++ b/acl_test.go
@@ -1,0 +1,238 @@
+package fastly
+
+import "testing"
+
+func TestClient_Acls(t *testing.T) {
+	t.Parallel()
+
+	var err error
+	var tv *Version
+	record(t, "acls/version", func(c *Client) {
+		tv = testVersion(t, c)
+	})
+
+	// Clean up
+	defer func() {
+		record(t, "acls/cleanup", func(c *Client) {
+			c.DeleteAcl(&DeleteAclInput{
+				Service: testServiceID,
+				Version: tv.Number,
+				Name:    "test_acl",
+			})
+
+			c.DeleteAcl(&DeleteAclInput{
+				Service: testServiceID,
+				Version: tv.Number,
+				Name:    "new_test_acl",
+			})
+		})
+	}()
+
+	// Create
+	var a *Acl
+	record(t, "acls/create", func(c *Client) {
+		a, err = c.CreateAcl(&CreateAclInput{
+			Service: testServiceID,
+			Version: tv.Number,
+			Name:    "test_acl",
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if a.Name != "test_acl" {
+		t.Errorf("bad name: %q", a.Name)
+	}
+
+	// List
+	var as []*Acl
+	record(t, "acls/list", func(c *Client) {
+		as, err = c.ListAcls(&ListAclsInput{
+			Service: testServiceID,
+			Version: tv.Number,
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(as) != 1 {
+		t.Errorf("bad acls: %v", as)
+	}
+
+	// Get
+	var na *Acl
+	record(t, "acls/get", func(c *Client) {
+		na, err = c.GetAcl(&GetAclInput{
+			Service: testServiceID,
+			Version: tv.Number,
+			Name:    "test_acl",
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a.Name != na.Name {
+		t.Errorf("bad name: %q (%q)", a.Name, na.Name)
+	}
+
+	// Update
+	var ua *Acl
+	record(t, "acls/update", func(c *Client) {
+		ua, err = c.UpdateAcl(&UpdateAclInput{
+			Service: testServiceID,
+			Version: tv.Number,
+			Name:    "test_acl",
+			NewName: "new_test_acl",
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ua.Name != "new_test_acl" {
+		t.Errorf("Bad name after update %s", ua.Name)
+	}
+
+	if a.ID != ua.ID {
+		t.Errorf("bad ACL id: %q (%q)", a.ID, ua.ID)
+	}
+
+	// Delete
+	record(t, "acls/delete", func(c *Client) {
+		err = c.DeleteAcl(&DeleteAclInput{
+			Service: testServiceID,
+			Version: tv.Number,
+			Name:    "new_test_acl",
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+}
+
+func TestClient_ListAcls_validation(t *testing.T) {
+	var err error
+	_, err = testClient.ListAcls(&ListAclsInput{
+		Service: "",
+	})
+	if err != ErrMissingService {
+		t.Errorf("bad error: %s", err)
+	}
+
+	_, err = testClient.ListAcls(&ListAclsInput{
+		Service: "foo",
+		Version: 0,
+	})
+	if err != ErrMissingVersion {
+		t.Errorf("bad error: %s", err)
+	}
+}
+
+func TestClient_CreateAcl_validation(t *testing.T) {
+	var err error
+	_, err = testClient.CreateAcl(&CreateAclInput{
+		Service: "",
+	})
+	if err != ErrMissingService {
+		t.Errorf("bad error: %s", err)
+	}
+
+	_, err = testClient.CreateAcl(&CreateAclInput{
+		Service: "foo",
+		Version: 0,
+	})
+	if err != ErrMissingVersion {
+		t.Errorf("bad error: %s", err)
+	}
+}
+
+func TestClient_GetAcl_validation(t *testing.T) {
+	var err error
+	_, err = testClient.GetAcl(&GetAclInput{
+		Service: "",
+	})
+	if err != ErrMissingService {
+		t.Errorf("bad error: %s", err)
+	}
+
+	_, err = testClient.GetAcl(&GetAclInput{
+		Service: "foo",
+		Version: 0,
+	})
+	if err != ErrMissingVersion {
+		t.Errorf("bad error: %s", err)
+	}
+
+	_, err = testClient.GetAcl(&GetAclInput{
+		Service: "foo",
+		Version: 1,
+		Name:    "",
+	})
+	if err != ErrMissingName {
+		t.Errorf("bad error: %s", err)
+	}
+}
+
+func TestClient_UpdateAcl_validation(t *testing.T) {
+	var err error
+	_, err = testClient.UpdateAcl(&UpdateAclInput{
+		Service: "",
+	})
+	if err != ErrMissingService {
+		t.Errorf("bad error: %s", err)
+	}
+
+	_, err = testClient.UpdateAcl(&UpdateAclInput{
+		Service: "foo",
+		Version: 0,
+	})
+	if err != ErrMissingVersion {
+		t.Errorf("bad error: %s", err)
+	}
+
+	_, err = testClient.UpdateAcl(&UpdateAclInput{
+		Service: "foo",
+		Version: 1,
+		Name:    "",
+	})
+	if err != ErrMissingName {
+		t.Errorf("bad error: %s", err)
+	}
+	_, err = testClient.UpdateAcl(&UpdateAclInput{
+		Service: "foo",
+		Version: 1,
+		Name:    "acl",
+		NewName: "",
+	})
+	if err != ErrMissingNewName {
+		t.Errorf("bad error: %s", err)
+	}
+}
+
+func TestClient_DeleteAcl_validation(t *testing.T) {
+	var err error
+	err = testClient.DeleteAcl(&DeleteAclInput{
+		Service: "",
+	})
+	if err != ErrMissingService {
+		t.Errorf("bad error: %s", err)
+	}
+
+	err = testClient.DeleteAcl(&DeleteAclInput{
+		Service: "foo",
+		Version: 0,
+	})
+	if err != ErrMissingVersion {
+		t.Errorf("bad error: %s", err)
+	}
+
+	err = testClient.DeleteAcl(&DeleteAclInput{
+		Service: "foo",
+		Version: 1,
+		Name:    "",
+	})
+	if err != ErrMissingName {
+		t.Errorf("bad error: %s", err)
+	}
+}

--- a/errors.go
+++ b/errors.go
@@ -63,6 +63,18 @@ var ErrMissingYear = errors.New("Missing required field 'Year'")
 // requires a "Month" key, but one was not set.
 var ErrMissingMonth = errors.New("Missing required field 'Month'")
 
+// ErrMissingNewName is an erorr that is returned when an input struct
+// requires a "NewName" key, but one was not set
+var ErrMissingNewName = errors.New("Missing required field 'NewName'")
+
+// ErrMissingAcl is an error that is returned when an unout struct
+// required an "Acl" key, but one is not set
+var ErrMissingAcl = errors.New("Missing required field 'Acl'")
+
+// ErrMissingIP is an error that is returned when an unout struct
+// required an "IP" key, but one is not set
+var ErrMissingIP = errors.New("Missing requried field 'IP'")
+
 // Ensure HTTPError is, in fact, an error.
 var _ error = (*HTTPError)(nil)
 


### PR DESCRIPTION
Implements an interface for Fastly's ACLs and ACL entries.

I did not include fixtures but have them all generated locally from my Fastly account.