### PR TITLE
Uppercase acl to ACL to follow golang standards

### DIFF
--- a/fastly/acl.go
+++ b/fastly/acl.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 )
 
-type Acl struct {
+type ACL struct {
 	ServiceID string `mapstructure:"service_id"`
 	Version   int    `mapstructure:"version"`
 
@@ -13,18 +13,18 @@ type Acl struct {
 	ID   string `mapstructure:"id"`
 }
 
-// aclsByName is a sortable list of ACLs.
-type aclsByName []*Acl
+// ACLsByName is a sortable list of ACLs.
+type ACLsByName []*ACL
 
 // Len, Swap, and Less implement the sortable interface.
-func (s aclsByName) Len() int      { return len(s) }
-func (s aclsByName) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
-func (s aclsByName) Less(i, j int) bool {
+func (s ACLsByName) Len() int      { return len(s) }
+func (s ACLsByName) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+func (s ACLsByName) Less(i, j int) bool {
 	return s[i].Name < s[j].Name
 }
 
-// ListAclsInput is used as input to the ListAcls function.
-type ListAclsInput struct {
+// ListACLsInput is used as input to the ListACLs function.
+type ListACLsInput struct {
 	// Service is the ID of the service (required).
 	Service string
 
@@ -32,8 +32,8 @@ type ListAclsInput struct {
 	Version int
 }
 
-// ListAcls returns the list of ACLs for the configuration version.
-func (c *Client) ListAcls(i *ListAclsInput) ([]*Acl, error) {
+// ListACLs returns the list of ACLs for the configuration version.
+func (c *Client) ListACLs(i *ListACLsInput) ([]*ACL, error) {
 	if i.Service == "" {
 		return nil, ErrMissingService
 	}
@@ -48,16 +48,16 @@ func (c *Client) ListAcls(i *ListAclsInput) ([]*Acl, error) {
 		return nil, err
 	}
 
-	var as []*Acl
+	var as []*ACL
 	if err := decodeJSON(&as, resp.Body); err != nil {
 		return nil, err
 	}
-	sort.Stable(aclsByName(as))
+	sort.Stable(ACLsByName(as))
 	return as, nil
 }
 
-// CreateAclInput is used as input to the CreateAcl function.
-type CreateAclInput struct {
+// CreateACLInput is used as input to the CreateACL function.
+type CreateACLInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
@@ -67,7 +67,7 @@ type CreateAclInput struct {
 	Name string `form:"name"`
 }
 
-func (c *Client) CreateAcl(i *CreateAclInput) (*Acl, error) {
+func (c *Client) CreateACL(i *CreateACLInput) (*ACL, error) {
 	if i.Service == "" {
 		return nil, ErrMissingService
 	}
@@ -82,26 +82,26 @@ func (c *Client) CreateAcl(i *CreateAclInput) (*Acl, error) {
 		return nil, err
 	}
 
-	var a *Acl
+	var a *ACL
 	if err := decodeJSON(&a, resp.Body); err != nil {
 		return nil, err
 	}
 	return a, nil
 }
 
-// DeleteAclInput is the input parameter to DeleteAcl function.
-type DeleteAclInput struct {
+// DeleteACLInput is the input parameter to DeleteACL function.
+type DeleteACLInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
 	Version int
 
-	// Name is the name of the acl to delete (required).
+	// Name is the name of the ACL to delete (required).
 	Name string
 }
 
-// DeleteAcl deletes the given acl version.
-func (c *Client) DeleteAcl(i *DeleteAclInput) error {
+// DeleteACL deletes the given ACL version.
+func (c *Client) DeleteACL(i *DeleteACLInput) error {
 	if i.Service == "" {
 		return ErrMissingService
 	}
@@ -130,19 +130,19 @@ func (c *Client) DeleteAcl(i *DeleteAclInput) error {
 	return nil
 }
 
-// GetAclInput is the input parameter to GetAcl function.
-type GetAclInput struct {
+// GetACLInput is the input parameter to GetACL function.
+type GetACLInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
 	Version int
 
-	// Name is the name of the acl to get (required).
+	// Name is the name of the ACL to get (required).
 	Name string
 }
 
-// GetAcl gets the ACL configuration with the given parameters.
-func (c *Client) GetAcl(i *GetAclInput) (*Acl, error) {
+// GetACL gets the ACL configuration with the given parameters.
+func (c *Client) GetACL(i *GetACLInput) (*ACL, error) {
 	if i.Service == "" {
 		return nil, ErrMissingService
 	}
@@ -161,29 +161,29 @@ func (c *Client) GetAcl(i *GetAclInput) (*Acl, error) {
 		return nil, err
 	}
 
-	var a *Acl
+	var a *ACL
 	if err := decodeJSON(&a, resp.Body); err != nil {
 		return nil, err
 	}
 	return a, nil
 }
 
-// UpdateAclInput is the input parameter to UpdateAcl function.
-type UpdateAclInput struct {
+// UpdateACLInput is the input parameter to UpdateACL function.
+type UpdateACLInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
 	Version int
 
-	// Name is the name of the acl to update (required).
+	// Name is the name of the ACL to update (required).
 	Name string
 
-	// NewName is the new name of the acl to update (required).
+	// NewName is the new name of the ACL to update (required).
 	NewName string `form:"name"`
 }
 
-// UpdateAcl updates the name of the ACL with the given parameters.
-func (c *Client) UpdateAcl(i *UpdateAclInput) (*Acl, error) {
+// UpdateACL updates the name of the ACL with the given parameters.
+func (c *Client) UpdateACL(i *UpdateACLInput) (*ACL, error) {
 	if i.Service == "" {
 		return nil, ErrMissingService
 	}
@@ -207,7 +207,7 @@ func (c *Client) UpdateAcl(i *UpdateAclInput) (*Acl, error) {
 		return nil, err
 	}
 
-	var a *Acl
+	var a *ACL
 	if err := decodeJSON(&a, resp.Body); err != nil {
 		return nil, err
 	}

--- a/fastly/acl_entry.go
+++ b/fastly/acl_entry.go
@@ -5,9 +5,9 @@ import (
 	"sort"
 )
 
-type AclEntry struct {
+type ACLEntry struct {
 	ServiceID string `mapstructure:"service_id"`
-	AclID     string `mapstructure:"acl_id"`
+	ACLID     string `mapstructure:"acl_id"`
 
 	ID      string `mapstructure:"id"`
 	IP      string `mapstructure:"ip"`
@@ -16,8 +16,8 @@ type AclEntry struct {
 	Comment string `mapstructure:"comment"`
 }
 
-// entriesById is a sortable list of Acl entries.
-type entriesById []*AclEntry
+// entriesById is a sortable list of ACL entries.
+type entriesById []*ACLEntry
 
 // Len, Swap, and Less implements the sortable interface.
 func (s entriesById) Len() int      { return len(s) }
@@ -26,30 +26,30 @@ func (s entriesById) Less(i, j int) bool {
 	return s[i].ID < s[j].ID
 }
 
-// ListAclEntriesInput is the input parameter to ListAclEntries function.
-type ListAclEntriesInput struct {
+// ListACLEntriesInput is the input parameter to ListACLEntries function.
+type ListACLEntriesInput struct {
 	Service string
-	Acl     string
+	ACL     string
 }
 
-// ListAclEntries return a list of entries for an Acl
-func (c *Client) ListAclEntries(i *ListAclEntriesInput) ([]*AclEntry, error) {
+// ListACLEntries return a list of entries for an ACL
+func (c *Client) ListACLEntries(i *ListACLEntriesInput) ([]*ACLEntry, error) {
 	if i.Service == "" {
 		return nil, ErrMissingService
 	}
 
-	if i.Acl == "" {
-		return nil, ErrMissingAcl
+	if i.ACL == "" {
+		return nil, ErrMissingACL
 	}
 
-	path := fmt.Sprintf("/service/%s/acl/%s/entries", i.Service, i.Acl)
+	path := fmt.Sprintf("/service/%s/acl/%s/entries", i.Service, i.ACL)
 
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	var es []*AclEntry
+	var es []*ACLEntry
 	if err := decodeJSON(&es, resp.Body); err != nil {
 		return nil, err
 	}
@@ -59,35 +59,35 @@ func (c *Client) ListAclEntries(i *ListAclEntriesInput) ([]*AclEntry, error) {
 	return es, nil
 }
 
-// GetAclEntryInput is the input parameter to GetAclEntry function.
-type GetAclEntryInput struct {
+// GetACLEntryInput is the input parameter to GetACLEntry function.
+type GetACLEntryInput struct {
 	Service string
-	Acl     string
+	ACL     string
 	ID      string
 }
 
-// GetAclEntry returns a single Acl entry based on its ID.
-func (c *Client) GetAclEntry(i *GetAclEntryInput) (*AclEntry, error) {
+// GetACLEntry returns a single ACL entry based on its ID.
+func (c *Client) GetACLEntry(i *GetACLEntryInput) (*ACLEntry, error) {
 	if i.Service == "" {
 		return nil, ErrMissingService
 	}
 
-	if i.Acl == "" {
-		return nil, ErrMissingAcl
+	if i.ACL == "" {
+		return nil, ErrMissingACL
 	}
 
 	if i.ID == "" {
 		return nil, ErrMissingID
 	}
 
-	path := fmt.Sprintf("/service/%s/acl/%s/entry/%s", i.Service, i.Acl, i.ID)
+	path := fmt.Sprintf("/service/%s/acl/%s/entry/%s", i.Service, i.ACL, i.ID)
 
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	var e *AclEntry
+	var e *ACLEntry
 	if err := decodeJSON(&e, resp.Body); err != nil {
 		return nil, err
 	}
@@ -95,11 +95,11 @@ func (c *Client) GetAclEntry(i *GetAclEntryInput) (*AclEntry, error) {
 	return e, nil
 }
 
-// CreateAclEntryInput the input parameter to CreateAclEntry function.
-type CreateAclEntryInput struct {
+// CreateACLEntryInput the input parameter to CreateACLEntry function.
+type CreateACLEntryInput struct {
 	// Required fields
 	Service string
-	Acl     string
+	ACL     string
 	IP      string `form:"ip"`
 
 	// Optional fields
@@ -108,28 +108,28 @@ type CreateAclEntryInput struct {
 	Comment string `form:"comment,omitempty"`
 }
 
-// CreateAclEntry creates and returns a new Acl entry.
-func (c *Client) CreateAclEntry(i *CreateAclEntryInput) (*AclEntry, error) {
+// CreateACLEntry creates and returns a new ACL entry.
+func (c *Client) CreateACLEntry(i *CreateACLEntryInput) (*ACLEntry, error) {
 	if i.Service == "" {
 		return nil, ErrMissingService
 	}
 
-	if i.Acl == "" {
-		return nil, ErrMissingAcl
+	if i.ACL == "" {
+		return nil, ErrMissingACL
 	}
 
 	if i.IP == "" {
 		return nil, ErrMissingIP
 	}
 
-	path := fmt.Sprintf("/service/%s/acl/%s/entry", i.Service, i.Acl)
+	path := fmt.Sprintf("/service/%s/acl/%s/entry", i.Service, i.ACL)
 
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	var e *AclEntry
+	var e *ACLEntry
 	if err := decodeJSON(&e, resp.Body); err != nil {
 		return nil, err
 	}
@@ -137,28 +137,28 @@ func (c *Client) CreateAclEntry(i *CreateAclEntryInput) (*AclEntry, error) {
 	return e, nil
 }
 
-// DeleteAclEntryInput the input parameter to DeleteAclEntry function.
-type DeleteAclEntryInput struct {
+// DeleteACLEntryInput the input parameter to DeleteACLEntry function.
+type DeleteACLEntryInput struct {
 	Service string
-	Acl     string
+	ACL     string
 	ID      string
 }
 
-// DeleteAclEntry deletes an entry from an Acl based on its ID
-func (c *Client) DeleteAclEntry(i *DeleteAclEntryInput) error {
+// DeleteACLEntry deletes an entry from an ACL based on its ID
+func (c *Client) DeleteACLEntry(i *DeleteACLEntryInput) error {
 	if i.Service == "" {
 		return ErrMissingService
 	}
 
-	if i.Acl == "" {
-		return ErrMissingAcl
+	if i.ACL == "" {
+		return ErrMissingACL
 	}
 
 	if i.ID == "" {
 		return ErrMissingID
 	}
 
-	path := fmt.Sprintf("/service/%s/acl/%s/entry/%s", i.Service, i.Acl, i.ID)
+	path := fmt.Sprintf("/service/%s/acl/%s/entry/%s", i.Service, i.ACL, i.ID)
 
 	resp, err := c.Delete(path, nil)
 	if err != nil {
@@ -178,11 +178,11 @@ func (c *Client) DeleteAclEntry(i *DeleteAclEntryInput) error {
 
 }
 
-// UpdateAclEntryInput is the input parameter to UpdateAclEntry function.
-type UpdateAclEntryInput struct {
+// UpdateACLEntryInput is the input parameter to UpdateACLEntry function.
+type UpdateACLEntryInput struct {
 	// Required fields
 	Service string
-	Acl     string
+	ACL     string
 	ID      string
 
 	// Optional fields
@@ -192,28 +192,28 @@ type UpdateAclEntryInput struct {
 	Comment string `form:"comment,omitempty"`
 }
 
-// UpdateAclEntry updates an Acl entry
-func (c *Client) UpdateAclEntry(i *UpdateAclEntryInput) (*AclEntry, error) {
+// UpdateACLEntry updates an ACL entry
+func (c *Client) UpdateACLEntry(i *UpdateACLEntryInput) (*ACLEntry, error) {
 	if i.Service == "" {
 		return nil, ErrMissingService
 	}
 
-	if i.Acl == "" {
-		return nil, ErrMissingAcl
+	if i.ACL == "" {
+		return nil, ErrMissingACL
 	}
 
 	if i.ID == "" {
 		return nil, ErrMissingID
 	}
 
-	path := fmt.Sprintf("/service/%s/acl/%s/entry/%s", i.Service, i.Acl, i.ID)
+	path := fmt.Sprintf("/service/%s/acl/%s/entry/%s", i.Service, i.ACL, i.ID)
 
 	resp, err := c.RequestForm("PATCH", path, i, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	var e *AclEntry
+	var e *ACLEntry
 	if err := decodeJSON(&e, resp.Body); err != nil {
 		return nil, err
 	}

--- a/fastly/acl_entry_test.go
+++ b/fastly/acl_entry_test.go
@@ -2,7 +2,7 @@ package fastly
 
 import "testing"
 
-func TestClient_AclEntries(t *testing.T) {
+func TestClient_ACLEntries(t *testing.T) {
 
 	var err error
 	var tv *Version
@@ -11,9 +11,9 @@ func TestClient_AclEntries(t *testing.T) {
 	})
 
 	// Create ACL before adding entries to it
-	var a *Acl
+	var a *ACL
 	record(t, "acl_entries/create_acl", func(c *Client) {
-		a, err = c.CreateAcl(&CreateAclInput{
+		a, err = c.CreateACL(&CreateACLInput{
 			Service: testServiceID,
 			Version: tv.Number,
 			Name:    "entry_acl",
@@ -23,10 +23,10 @@ func TestClient_AclEntries(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Clean up helper Acl
+	// Clean up helper ACL
 	defer func() {
 		record(t, "acl_entries/cleanup", func(c *Client) {
-			err = c.DeleteAcl(&DeleteAclInput{
+			err = c.DeleteACL(&DeleteACLInput{
 				Service: testServiceID,
 				Version: tv.Number,
 				Name:    "entry_acl",
@@ -35,11 +35,11 @@ func TestClient_AclEntries(t *testing.T) {
 	}()
 
 	// Create
-	var e *AclEntry
+	var e *ACLEntry
 	record(t, "acl_entries/create", func(c *Client) {
-		e, err = c.CreateAclEntry(&CreateAclEntryInput{
+		e, err = c.CreateACLEntry(&CreateACLEntryInput{
 			Service: testServiceID,
-			Acl:     a.ID,
+			ACL:     a.ID,
 			IP:      "10.0.0.3",
 			Subnet:  "8",
 			Negated: false,
@@ -67,11 +67,11 @@ func TestClient_AclEntries(t *testing.T) {
 	}
 
 	// List
-	var es []*AclEntry
+	var es []*ACLEntry
 	record(t, "acl_entries/list", func(c *Client) {
-		es, err = c.ListAclEntries(&ListAclEntriesInput{
+		es, err = c.ListACLEntries(&ListACLEntriesInput{
 			Service: testServiceID,
-			Acl:     a.ID,
+			ACL:     a.ID,
 		})
 	})
 	if err != nil {
@@ -83,11 +83,11 @@ func TestClient_AclEntries(t *testing.T) {
 	}
 
 	// Get
-	var ne *AclEntry
+	var ne *ACLEntry
 	record(t, "acl_entries/get", func(c *Client) {
-		ne, err = c.GetAclEntry(&GetAclEntryInput{
+		ne, err = c.GetACLEntry(&GetACLEntryInput{
 			Service: testServiceID,
-			Acl:     a.ID,
+			ACL:     a.ID,
 			ID:      e.ID,
 		})
 	})
@@ -109,11 +109,11 @@ func TestClient_AclEntries(t *testing.T) {
 	}
 
 	// Update
-	var ue *AclEntry
+	var ue *ACLEntry
 	record(t, "acl_entries/update", func(c *Client) {
-		ue, err = c.UpdateAclEntry(&UpdateAclEntryInput{
+		ue, err = c.UpdateACLEntry(&UpdateACLEntryInput{
 			Service: testServiceID,
-			Acl:     a.ID,
+			ACL:     a.ID,
 			ID:      e.ID,
 			IP:      "10.0.0.4",
 			Negated: true,
@@ -140,9 +140,9 @@ func TestClient_AclEntries(t *testing.T) {
 
 	// Delete
 	record(t, "acl_entries/delete", func(c *Client) {
-		err = c.DeleteAclEntry(&DeleteAclEntryInput{
+		err = c.DeleteACLEntry(&DeleteACLEntryInput{
 			Service: testServiceID,
-			Acl:     a.ID,
+			ACL:     a.ID,
 			ID:      e.ID,
 		})
 	})
@@ -152,62 +152,62 @@ func TestClient_AclEntries(t *testing.T) {
 
 }
 
-func TestClient_ListAclEntries_validation(t *testing.T) {
+func TestClient_ListACLEntries_validation(t *testing.T) {
 	var err error
-	_, err = testClient.ListAclEntries(&ListAclEntriesInput{
+	_, err = testClient.ListACLEntries(&ListACLEntriesInput{
 		Service: "",
 	})
 	if err != ErrMissingService {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.ListAclEntries(&ListAclEntriesInput{
+	_, err = testClient.ListACLEntries(&ListACLEntriesInput{
 		Service: "foo",
-		Acl:     "",
+		ACL:     "",
 	})
-	if err != ErrMissingAcl {
+	if err != ErrMissingACL {
 		t.Errorf("bad error: %s", err)
 	}
 }
 
-func TestClient_CreateAclEntry_validation(t *testing.T) {
+func TestClient_CreateACLEntry_validation(t *testing.T) {
 	var err error
-	_, err = testClient.CreateAclEntry(&CreateAclEntryInput{
+	_, err = testClient.CreateACLEntry(&CreateACLEntryInput{
 		Service: "",
 	})
 	if err != ErrMissingService {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.CreateAclEntry(&CreateAclEntryInput{
+	_, err = testClient.CreateACLEntry(&CreateACLEntryInput{
 		Service: "foo",
-		Acl:     "",
+		ACL:     "",
 	})
-	if err != ErrMissingAcl {
+	if err != ErrMissingACL {
 		t.Errorf("bad error: %s", err)
 	}
 }
 
-func TestClient_GetAclEntry_validation(t *testing.T) {
+func TestClient_GetACLEntry_validation(t *testing.T) {
 	var err error
-	_, err = testClient.GetAclEntry(&GetAclEntryInput{
+	_, err = testClient.GetACLEntry(&GetACLEntryInput{
 		Service: "",
 	})
 	if err != ErrMissingService {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetAclEntry(&GetAclEntryInput{
+	_, err = testClient.GetACLEntry(&GetACLEntryInput{
 		Service: "foo",
-		Acl:     "",
+		ACL:     "",
 	})
-	if err != ErrMissingAcl {
+	if err != ErrMissingACL {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetAclEntry(&GetAclEntryInput{
+	_, err = testClient.GetACLEntry(&GetACLEntryInput{
 		Service: "foo",
-		Acl:     "acl",
+		ACL:     "acl",
 		ID:      "",
 	})
 	if err != ErrMissingID {
@@ -215,26 +215,26 @@ func TestClient_GetAclEntry_validation(t *testing.T) {
 	}
 }
 
-func TestClient_UpdateAclEntry_validation(t *testing.T) {
+func TestClient_UpdateACLEntry_validation(t *testing.T) {
 	var err error
-	_, err = testClient.UpdateAclEntry(&UpdateAclEntryInput{
+	_, err = testClient.UpdateACLEntry(&UpdateACLEntryInput{
 		Service: "",
 	})
 	if err != ErrMissingService {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateAclEntry(&UpdateAclEntryInput{
+	_, err = testClient.UpdateACLEntry(&UpdateACLEntryInput{
 		Service: "foo",
-		Acl:     "",
+		ACL:     "",
 	})
-	if err != ErrMissingAcl {
+	if err != ErrMissingACL {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateAclEntry(&UpdateAclEntryInput{
+	_, err = testClient.UpdateACLEntry(&UpdateACLEntryInput{
 		Service: "foo",
-		Acl:     "acl",
+		ACL:     "acl",
 		ID:      "",
 	})
 	if err != ErrMissingID {
@@ -242,26 +242,26 @@ func TestClient_UpdateAclEntry_validation(t *testing.T) {
 	}
 }
 
-func TestClient_DeleteAclEntry_validation(t *testing.T) {
+func TestClient_DeleteACLEntry_validation(t *testing.T) {
 	var err error
-	err = testClient.DeleteAclEntry(&DeleteAclEntryInput{
+	err = testClient.DeleteACLEntry(&DeleteACLEntryInput{
 		Service: "",
 	})
 	if err != ErrMissingService {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteAclEntry(&DeleteAclEntryInput{
+	err = testClient.DeleteACLEntry(&DeleteACLEntryInput{
 		Service: "foo",
-		Acl:     "",
+		ACL:     "",
 	})
-	if err != ErrMissingAcl {
+	if err != ErrMissingACL {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteAclEntry(&DeleteAclEntryInput{
+	err = testClient.DeleteACLEntry(&DeleteACLEntryInput{
 		Service: "foo",
-		Acl:     "acl",
+		ACL:     "acl",
 		ID:      "",
 	})
 	if err != ErrMissingID {

--- a/fastly/acl_test.go
+++ b/fastly/acl_test.go
@@ -2,7 +2,7 @@ package fastly
 
 import "testing"
 
-func TestClient_Acls(t *testing.T) {
+func TestClient_ACLs(t *testing.T) {
 	t.Parallel()
 
 	var err error
@@ -14,13 +14,13 @@ func TestClient_Acls(t *testing.T) {
 	// Clean up
 	defer func() {
 		record(t, "acls/cleanup", func(c *Client) {
-			c.DeleteAcl(&DeleteAclInput{
+			c.DeleteACL(&DeleteACLInput{
 				Service: testServiceID,
 				Version: tv.Number,
 				Name:    "test_acl",
 			})
 
-			c.DeleteAcl(&DeleteAclInput{
+			c.DeleteACL(&DeleteACLInput{
 				Service: testServiceID,
 				Version: tv.Number,
 				Name:    "new_test_acl",
@@ -29,9 +29,9 @@ func TestClient_Acls(t *testing.T) {
 	}()
 
 	// Create
-	var a *Acl
+	var a *ACL
 	record(t, "acls/create", func(c *Client) {
-		a, err = c.CreateAcl(&CreateAclInput{
+		a, err = c.CreateACL(&CreateACLInput{
 			Service: testServiceID,
 			Version: tv.Number,
 			Name:    "test_acl",
@@ -46,9 +46,9 @@ func TestClient_Acls(t *testing.T) {
 	}
 
 	// List
-	var as []*Acl
+	var as []*ACL
 	record(t, "acls/list", func(c *Client) {
-		as, err = c.ListAcls(&ListAclsInput{
+		as, err = c.ListACLs(&ListACLsInput{
 			Service: testServiceID,
 			Version: tv.Number,
 		})
@@ -57,13 +57,13 @@ func TestClient_Acls(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(as) != 1 {
-		t.Errorf("bad acls: %v", as)
+		t.Errorf("bad ACLs: %v", as)
 	}
 
 	// Get
-	var na *Acl
+	var na *ACL
 	record(t, "acls/get", func(c *Client) {
-		na, err = c.GetAcl(&GetAclInput{
+		na, err = c.GetACL(&GetACLInput{
 			Service: testServiceID,
 			Version: tv.Number,
 			Name:    "test_acl",
@@ -77,9 +77,9 @@ func TestClient_Acls(t *testing.T) {
 	}
 
 	// Update
-	var ua *Acl
+	var ua *ACL
 	record(t, "acls/update", func(c *Client) {
-		ua, err = c.UpdateAcl(&UpdateAclInput{
+		ua, err = c.UpdateACL(&UpdateACLInput{
 			Service: testServiceID,
 			Version: tv.Number,
 			Name:    "test_acl",
@@ -99,7 +99,7 @@ func TestClient_Acls(t *testing.T) {
 
 	// Delete
 	record(t, "acls/delete", func(c *Client) {
-		err = c.DeleteAcl(&DeleteAclInput{
+		err = c.DeleteACL(&DeleteACLInput{
 			Service: testServiceID,
 			Version: tv.Number,
 			Name:    "new_test_acl",
@@ -111,16 +111,16 @@ func TestClient_Acls(t *testing.T) {
 
 }
 
-func TestClient_ListAcls_validation(t *testing.T) {
+func TestClient_ListACLs_validation(t *testing.T) {
 	var err error
-	_, err = testClient.ListAcls(&ListAclsInput{
+	_, err = testClient.ListACLs(&ListACLsInput{
 		Service: "",
 	})
 	if err != ErrMissingService {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.ListAcls(&ListAclsInput{
+	_, err = testClient.ListACLs(&ListACLsInput{
 		Service: "foo",
 		Version: 0,
 	})
@@ -129,16 +129,16 @@ func TestClient_ListAcls_validation(t *testing.T) {
 	}
 }
 
-func TestClient_CreateAcl_validation(t *testing.T) {
+func TestClient_CreateACL_validation(t *testing.T) {
 	var err error
-	_, err = testClient.CreateAcl(&CreateAclInput{
+	_, err = testClient.CreateACL(&CreateACLInput{
 		Service: "",
 	})
 	if err != ErrMissingService {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.CreateAcl(&CreateAclInput{
+	_, err = testClient.CreateACL(&CreateACLInput{
 		Service: "foo",
 		Version: 0,
 	})
@@ -147,16 +147,16 @@ func TestClient_CreateAcl_validation(t *testing.T) {
 	}
 }
 
-func TestClient_GetAcl_validation(t *testing.T) {
+func TestClient_GetACL_validation(t *testing.T) {
 	var err error
-	_, err = testClient.GetAcl(&GetAclInput{
+	_, err = testClient.GetACL(&GetACLInput{
 		Service: "",
 	})
 	if err != ErrMissingService {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetAcl(&GetAclInput{
+	_, err = testClient.GetACL(&GetACLInput{
 		Service: "foo",
 		Version: 0,
 	})
@@ -164,7 +164,7 @@ func TestClient_GetAcl_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetAcl(&GetAclInput{
+	_, err = testClient.GetACL(&GetACLInput{
 		Service: "foo",
 		Version: 1,
 		Name:    "",
@@ -174,16 +174,16 @@ func TestClient_GetAcl_validation(t *testing.T) {
 	}
 }
 
-func TestClient_UpdateAcl_validation(t *testing.T) {
+func TestClient_UpdateACL_validation(t *testing.T) {
 	var err error
-	_, err = testClient.UpdateAcl(&UpdateAclInput{
+	_, err = testClient.UpdateACL(&UpdateACLInput{
 		Service: "",
 	})
 	if err != ErrMissingService {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateAcl(&UpdateAclInput{
+	_, err = testClient.UpdateACL(&UpdateACLInput{
 		Service: "foo",
 		Version: 0,
 	})
@@ -191,7 +191,7 @@ func TestClient_UpdateAcl_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateAcl(&UpdateAclInput{
+	_, err = testClient.UpdateACL(&UpdateACLInput{
 		Service: "foo",
 		Version: 1,
 		Name:    "",
@@ -199,7 +199,7 @@ func TestClient_UpdateAcl_validation(t *testing.T) {
 	if err != ErrMissingName {
 		t.Errorf("bad error: %s", err)
 	}
-	_, err = testClient.UpdateAcl(&UpdateAclInput{
+	_, err = testClient.UpdateACL(&UpdateACLInput{
 		Service: "foo",
 		Version: 1,
 		Name:    "acl",
@@ -210,16 +210,16 @@ func TestClient_UpdateAcl_validation(t *testing.T) {
 	}
 }
 
-func TestClient_DeleteAcl_validation(t *testing.T) {
+func TestClient_DeleteACL_validation(t *testing.T) {
 	var err error
-	err = testClient.DeleteAcl(&DeleteAclInput{
+	err = testClient.DeleteACL(&DeleteACLInput{
 		Service: "",
 	})
 	if err != ErrMissingService {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteAcl(&DeleteAclInput{
+	err = testClient.DeleteACL(&DeleteACLInput{
 		Service: "foo",
 		Version: 0,
 	})
@@ -227,7 +227,7 @@ func TestClient_DeleteAcl_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteAcl(&DeleteAclInput{
+	err = testClient.DeleteACL(&DeleteACLInput{
 		Service: "foo",
 		Version: 1,
 		Name:    "",

--- a/fastly/errors.go
+++ b/fastly/errors.go
@@ -69,7 +69,7 @@ var ErrMissingNewName = errors.New("Missing required field 'NewName'")
 
 // ErrMissingAcl is an error that is returned when an unout struct
 // required an "Acl" key, but one is not set
-var ErrMissingAcl = errors.New("Missing required field 'Acl'")
+var ErrMissingACL = errors.New("Missing required field 'ACL'")
 
 // ErrMissingIP is an error that is returned when an unout struct
 // required an "IP" key, but one is not set


### PR DESCRIPTION
Uppercase to `*ACL*` to follow the golang naming conventions.