### PR TITLE
Add ability to configure format_version for LE

### DIFF
--- a/fastly/fixtures/logentries/create.yaml
+++ b/fastly/fixtures/logentries/create.yaml
@@ -29,7 +29,7 @@ interactions:
     url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/674/logging/logentries
     method: POST
   response:
-    body: '{"format":"format","name":"test-logentries","port":"1234","token":"abcd1234","use_tls":"1","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":"674","placement":null,"format_version":"2","response_condition":"","public_key":null,"updated_at":"2017-07-20T01:15:03+00:00","deleted_at":null,"created_at":"2017-07-20T01:15:03+00:00"}'
+    body: '{"format":"format","name":"test-logentries","port":"1234","token":"abcd1234","use_tls":"1","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":"674","placement":null,"format_version":"1","response_condition":"","public_key":null,"updated_at":"2017-07-20T01:15:03+00:00","deleted_at":null,"created_at":"2017-07-20T01:15:03+00:00"}'
     headers:
       Accept-Ranges:
       - bytes

--- a/fastly/fixtures/logentries/get.yaml
+++ b/fastly/fixtures/logentries/get.yaml
@@ -13,7 +13,7 @@ interactions:
     url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/674/logging/logentries/test-logentries
     method: GET
   response:
-    body: '{"placement":null,"format_version":"2","response_condition":"","public_key":null,"updated_at":"2017-07-20T01:15:03+00:00","name":"test-logentries","port":"1234","use_tls":"1","service_id":"7i6HN3TK9wS159v2gPAZ8A","token":"abcd1234","version":"674","deleted_at":null,"created_at":"2017-07-20T01:15:03+00:00","format":"format"}'
+    body: '{"placement":null,"format_version":"1","response_condition":"","public_key":null,"updated_at":"2017-07-20T01:15:03+00:00","name":"test-logentries","port":"1234","use_tls":"1","service_id":"7i6HN3TK9wS159v2gPAZ8A","token":"abcd1234","version":"674","deleted_at":null,"created_at":"2017-07-20T01:15:03+00:00","format":"format"}'
     headers:
       Accept-Ranges:
       - bytes

--- a/fastly/logentries.go
+++ b/fastly/logentries.go
@@ -16,6 +16,7 @@ type Logentries struct {
 	UseTLS            bool       `mapstructure:"use_tls"`
 	Token             string     `mapstructure:"token"`
 	Format            string     `mapstructure:"format"`
+	FormatVersion     uint       `mapstructure:"format_version"`
 	ResponseCondition string     `mapstructure:"response_condition"`
 	CreatedAt         *time.Time `mapstructure:"created_at"`
 	UpdatedAt         *time.Time `mapstructure:"updated_at"`
@@ -77,6 +78,7 @@ type CreateLogentriesInput struct {
 	UseTLS            *Compatibool `form:"use_tls,omitempty"`
 	Token             string       `form:"token,omitempty"`
 	Format            string       `form:"format,omitempty"`
+	FormatVersion     uint         `form:"format_version,omitempty"`
 	ResponseCondition string       `form:"response_condition,omitempty"`
 }
 
@@ -156,6 +158,7 @@ type UpdateLogentriesInput struct {
 	UseTLS            *Compatibool `form:"use_tls,omitempty"`
 	Token             string       `form:"token,omitempty"`
 	Format            string       `form:"format,omitempty"`
+	FormatVersion     uint         `form:"format_version,omitempty"`
 	ResponseCondition string       `form:"response_condition,omitempty"`
 }
 

--- a/fastly/logentries_test.go
+++ b/fastly/logentries_test.go
@@ -60,6 +60,9 @@ func TestClient_Logentries(t *testing.T) {
 	if le.Format != "format" {
 		t.Errorf("bad format: %q", le.Format)
 	}
+	if le.FormatVersion != 1 {
+		t.Errorf("bad format_version: %q", le.FormatVersion)
+	}
 
 	// List
 	var les []*Logentries
@@ -103,15 +106,19 @@ func TestClient_Logentries(t *testing.T) {
 	if le.Format != nle.Format {
 		t.Errorf("bad format: %q", le.Format)
 	}
+	if le.FormatVersion != nle.FormatVersion {
+		t.Errorf("bad format_version: %q", le.FormatVersion)
+	}
 
 	// Update
 	var ule *Logentries
 	record(t, "logentries/update", func(c *Client) {
 		ule, err = c.UpdateLogentries(&UpdateLogentriesInput{
-			Service: testServiceID,
-			Version: tv.Number,
-			Name:    "test-logentries",
-			NewName: "new-test-logentries",
+			Service:       testServiceID,
+			Version:       tv.Number,
+			Name:          "test-logentries",
+			NewName:       "new-test-logentries",
+			FormatVersion: 2,
 		})
 	})
 	if err != nil {
@@ -119,6 +126,9 @@ func TestClient_Logentries(t *testing.T) {
 	}
 	if ule.Name != "new-test-logentries" {
 		t.Errorf("bad name: %q", ule.Name)
+	}
+	if ule.FormatVersion != 2 {
+		t.Errorf("bad format_version: %q", ule.FormatVersion)
 	}
 
 	// Delete


### PR DESCRIPTION
Being able to set format_version (which is supported by Fastly API as per [[1]](https://docs.fastly.com/api/logging#logging_logentries)) means we can utilise Version 2 log format [[2]](https://docs.fastly.com/guides/streaming-logs/custom-log-formats#version-2-log-format) in Fastly and send more rich data to Logentries.  

[1] https://docs.fastly.com/api/logging#logging_logentries
[2] https://docs.fastly.com/guides/streaming-logs/custom-log-formats#version-2-log-format

