### PR TITLE
Add support for specifying message_type in gcs

### DIFF
--- a/fastly/fixtures/gcses/create.yaml
+++ b/fastly/fixtures/gcses/create.yaml
@@ -37,7 +37,7 @@ interactions:
     url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/685/logging/gcs
     method: POST
   response:
-    body: '{"bucket_name":"bucket","format":"format","gzip_level":"9","name":"test-gcs","path":"/path","period":"12","secret_key":"key","timestamp_format":"%Y","user":"user","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":"685","placement":null,"format_version":"2","response_condition":"","public_key":null,"updated_at":"2017-07-20T01:15:09+00:00","message_type":"classic","deleted_at":null,"created_at":"2017-07-20T01:15:09+00:00"}'
+    body: '{"bucket_name":"bucket","format":"format","gzip_level":"9","name":"test-gcs","path":"/path","period":"12","secret_key":"key","timestamp_format":"%Y","user":"user","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":"685","placement":null,"format_version":"2","response_condition":"","public_key":null,"updated_at":"2017-07-20T01:15:09+00:00","message_type":"blank","deleted_at":null,"created_at":"2017-07-20T01:15:09+00:00"}'
     headers:
       Accept-Ranges:
       - bytes

--- a/fastly/gcs.go
+++ b/fastly/gcs.go
@@ -18,6 +18,7 @@ type GCS struct {
 	Period            uint   `mapstructure:"period"`
 	GzipLevel         uint8  `mapstructure:"gzip_level"`
 	Format            string `mapstructure:"format"`
+	MessageType       string `mapstructure:"message_type"`
 	ResponseCondition string `mapstructure:"response_condition"`
 	TimestampFormat   string `mapstructure:"timestamp_format"`
 }
@@ -80,6 +81,7 @@ type CreateGCSInput struct {
 	Period            uint   `form:"period,omitempty"`
 	GzipLevel         uint8  `form:"gzip_level,omitempty"`
 	Format            string `form:"format,omitempty"`
+	MessageType       string `form:"message_type,omitempty"`
 	ResponseCondition string `form:"response_condition,omitempty"`
 	TimestampFormat   string `form:"timestamp_format,omitempty"`
 }

--- a/fastly/gcs_test.go
+++ b/fastly/gcs_test.go
@@ -25,6 +25,7 @@ func TestClient_GCSs(t *testing.T) {
 			Period:          12,
 			GzipLevel:       9,
 			Format:          "format",
+			MessageType:     "blank",
 			TimestampFormat: "%Y",
 		})
 	})
@@ -75,6 +76,9 @@ func TestClient_GCSs(t *testing.T) {
 	}
 	if gcs.TimestampFormat != "%Y" {
 		t.Errorf("bad timestamp_format: %q", gcs.TimestampFormat)
+	}
+	if gcs.MessageType != "blank" {
+		t.Errorf("bad message_type: %q", gcs.MessageType)
 	}
 
 	// List
@@ -130,6 +134,9 @@ func TestClient_GCSs(t *testing.T) {
 	}
 	if gcs.TimestampFormat != "%Y" {
 		t.Errorf("bad timestamp_format: %q", gcs.TimestampFormat)
+	}
+	if gcs.MessageType != "blank" {
+		t.Errorf("bad message_type: %q", gcs.MessageType)
 	}
 
 	// Update


### PR DESCRIPTION
Per the API https://docs.fastly.com/api/logging#logging_gcs this allows
a user to get/set the message_type field when setting up GCS logging.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sethvargo/go-fastly/52)
<!-- Reviewable:end -->
