### PR TITLE
Add support for `placement` when creating a new logging endpoint

### DIFF
--- a/fastly/logentries.go
+++ b/fastly/logentries.go
@@ -80,6 +80,7 @@ type CreateLogentriesInput struct {
 	Format            string       `form:"format,omitempty"`
 	FormatVersion     uint         `form:"format_version,omitempty"`
 	ResponseCondition string       `form:"response_condition,omitempty"`
+	Placement         string       `form:"placement,omitempty"`
 }
 
 // CreateLogentries creates a new Fastly logentries.

--- a/fastly/papertrail.go
+++ b/fastly/papertrail.go
@@ -79,6 +79,7 @@ type CreatePapertrailInput struct {
 	CreatedAt         *time.Time `form:"created_at,omitempty"`
 	UpdatedAt         *time.Time `form:"updated_at,omitempty"`
 	DeletedAt         *time.Time `form:"deleted_at,omitempty"`
+	Placement         string     `form:"placement,omitempty"`
 }
 
 // CreatePapertrail creates a new Fastly papertrail.

--- a/fastly/s3.go
+++ b/fastly/s3.go
@@ -101,6 +101,7 @@ type CreateS3Input struct {
 	ResponseCondition string       `form:"response_condition,omitempty"`
 	TimestampFormat   string       `form:"timestamp_format,omitempty"`
 	Redundancy        S3Redundancy `form:"redundancy,omitempty"`
+        Placement         string        `form:"placement,omitempty"`
 }
 
 // CreateS3 creates a new Fastly S3.

--- a/fastly/s3.go
+++ b/fastly/s3.go
@@ -101,7 +101,7 @@ type CreateS3Input struct {
 	ResponseCondition string       `form:"response_condition,omitempty"`
 	TimestampFormat   string       `form:"timestamp_format,omitempty"`
 	Redundancy        S3Redundancy `form:"redundancy,omitempty"`
-        Placement         string        `form:"placement,omitempty"`
+        Placement         string       `form:"placement,omitempty"`
 }
 
 // CreateS3 creates a new Fastly S3.

--- a/fastly/sumologic.go
+++ b/fastly/sumologic.go
@@ -80,6 +80,7 @@ type CreateSumologicInput struct {
 	ResponseCondition string `form:"response_condition,omitempty"`
 	MessageType       string `form:"message_type,omitempty"`
 	FormatVersion     int    `form:"format_version,omitempty"`
+	Placement         string `form:"placement,omitempty"`
 }
 
 // CreateSumologic creates a new Fastly sumologic.

--- a/fastly/syslog.go
+++ b/fastly/syslog.go
@@ -92,6 +92,7 @@ type CreateSyslogInput struct {
 	FormatVersion     uint         `form:"format_version,omitempty"`
 	MessageType       string       `form:"message_type,omitempty"`
 	ResponseCondition string       `form:"response_condition,omitempty"`
+	Placement         string       `form:"placement,omitempty"`
 }
 
 // CreateSyslog creates a new Fastly syslog.


### PR DESCRIPTION
Add support for the `placement` field (described here: https://docs.fastly.com/guides/web-application-firewall/fastly-waf-logging#waf_debug_log) to allow a logging endpoint to be used for waf logs.