### PR TITLE
Use "Service" instead of "ServiceID" for VCL Snippets

### DIFF
--- a/fastly/errors.go
+++ b/fastly/errors.go
@@ -13,10 +13,6 @@ import (
 // a "Service" key, but one was not set.
 var ErrMissingService = errors.New("Missing required field 'Service'")
 
-// ErrMissingServiceID is an error that is returned when an input struct requires
-// a "ServiceID" key, but one was not set.
-var ErrMissingServiceID = errors.New("Missing required field 'ServiceID'")
-
 // ErrMissingStatus is an error that is returned when an input struct requires
 // a "Status" key, but one was not set.
 var ErrMissingStatus = errors.New("Missing required field 'Status'")

--- a/fastly/vcl_snippets.go
+++ b/fastly/vcl_snippets.go
@@ -53,8 +53,8 @@ type CreateSnippetInput struct {
 	// Content is the VCL code that specifies exactly what the snippet does.
 	Content string `form:"content"`
 
-	// ServiceID is the ID of the Service to add the snippet to.
-	ServiceID string
+	// Service is the ID of the Service to add the snippet to.
+	Service string
 
 	// Type is the location in generated VCL where the snippet should be placed.
 	Type string `form:"type"`
@@ -62,8 +62,8 @@ type CreateSnippetInput struct {
 
 // CreateSnippet creates a new snippet or dynamic snippet on a unlocked version
 func (c *Client) CreateSnippet(i *CreateSnippetInput) (*Snippet, error) {
-	if i.ServiceID == "" {
-		return nil, ErrMissingServiceID
+	if i.Service == "" {
+		return nil, ErrMissingService
 	}
 
 	if i.Version == 0 {
@@ -82,7 +82,7 @@ func (c *Client) CreateSnippet(i *CreateSnippetInput) (*Snippet, error) {
 		return nil, ErrMissingSnippetType
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/snippet", i.ServiceID, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/snippet", i.Service, i.Version)
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -97,7 +97,7 @@ func (c *Client) CreateSnippet(i *CreateSnippetInput) (*Snippet, error) {
 
 // DynamicSnippet is the object returned when updating or retrieving a Dynamic Snippet
 type DynamicSnippet struct {
-	// ServiceID is the ID of the Service to add the snippet to.
+	// Service is the ID of the Service to add the snippet to.
 	ServiceID string `mapstructure:"service_id"`
 
 	// SnippetID is the ID of the Snippet to modify
@@ -112,8 +112,8 @@ type DynamicSnippet struct {
 
 // UpdateDynamicSnippetInput is the input for UpdateDynamicSnippet
 type UpdateDynamicSnippetInput struct {
-	// ServiceID is the ID of the Service to add the snippet to.
-	ServiceID string
+	// Service is the ID of the Service to add the snippet to.
+	Service string
 
 	// SnippetID is the ID of the Snippet to modify
 	SnippetID string
@@ -124,7 +124,7 @@ type UpdateDynamicSnippetInput struct {
 
 // UpdateDynamicSnippet replaces the content of a Dynamic Snippet
 func (c *Client) UpdateDynamicSnippet(i *UpdateDynamicSnippetInput) (*DynamicSnippet, error) {
-	if i.ServiceID == "" {
+	if i.Service == "" {
 		return nil, ErrMissingService
 	}
 
@@ -132,7 +132,7 @@ func (c *Client) UpdateDynamicSnippet(i *UpdateDynamicSnippetInput) (*DynamicSni
 		return nil, ErrMissingSnippetID
 	}
 
-	path := fmt.Sprintf("/service/%s/snippet/%s", i.ServiceID, i.SnippetID)
+	path := fmt.Sprintf("/service/%s/snippet/%s", i.Service, i.SnippetID)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -146,8 +146,8 @@ func (c *Client) UpdateDynamicSnippet(i *UpdateDynamicSnippetInput) (*DynamicSni
 }
 
 type DeleteSnippetInput struct {
-	// ServiceID is the ID of the Service to add the snippet to.
-	ServiceID string
+	// Service is the ID of the Service to add the snippet to.
+	Service string
 
 	// SnippetName is the Name of the Snippet to Delete
 	SnippetName string
@@ -157,7 +157,7 @@ type DeleteSnippetInput struct {
 }
 
 func (c *Client) DeleteSnippet(i *DeleteSnippetInput) error {
-	if i.ServiceID == "" {
+	if i.Service == "" {
 		return ErrMissingService
 	}
 
@@ -169,7 +169,7 @@ func (c *Client) DeleteSnippet(i *DeleteSnippetInput) error {
 		return ErrMissingSnippetName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/snippet/%s", i.ServiceID, i.Version, i.SnippetName)
+	path := fmt.Sprintf("/service/%s/version/%d/snippet/%s", i.Service, i.Version, i.SnippetName)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err
@@ -187,8 +187,8 @@ func (c *Client) DeleteSnippet(i *DeleteSnippetInput) error {
 
 // ListSnippetsInput is used as input to the ListSnippets function.
 type ListSnippetsInput struct {
-	// ServiceID is the ID of the service (required).
-	ServiceID string
+	// Service is the ID of the service (required).
+	Service string
 
 	// Version is the specific configuration version (required).
 	Version int
@@ -207,15 +207,15 @@ func (s snippetsByName) Less(i, j int) bool {
 // ListSnippets returns the list of Snippets for the configuration version. Content is not displayed for Dynmanic Snippets due to them being
 // versionless, use the GetDynamicSnippet function to show current content.
 func (c *Client) ListSnippets(i *ListSnippetsInput) ([]*Snippet, error) {
-	if i.ServiceID == "" {
-		return nil, ErrMissingServiceID
+	if i.Service == "" {
+		return nil, ErrMissingService
 	}
 
 	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/snippet", i.ServiceID, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/snippet", i.Service, i.Version)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -231,10 +231,10 @@ func (c *Client) ListSnippets(i *ListSnippetsInput) ([]*Snippet, error) {
 
 // GetSnippetInput is used as input to the GetSnippet function.
 type GetSnippetInput struct {
-	// ServiceID is the ID of the service. Version is the specific configuration
+	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
-	ServiceID string
-	Version   int
+	Service string
+	Version int
 
 	// SnippetName is the name of the Snippet to fetch.
 	SnippetName string
@@ -243,8 +243,8 @@ type GetSnippetInput struct {
 // GetSnippet gets the Snippet configuration with the given parameters. Dynamic Snippets will not show content due to them
 // being versionless, use GetDynamicSnippet to see content.
 func (c *Client) GetSnippet(i *GetSnippetInput) (*Snippet, error) {
-	if i.ServiceID == "" {
-		return nil, ErrMissingServiceID
+	if i.Service == "" {
+		return nil, ErrMissingService
 	}
 
 	if i.Version == 0 {
@@ -255,7 +255,7 @@ func (c *Client) GetSnippet(i *GetSnippetInput) (*Snippet, error) {
 		return nil, ErrMissingSnippetName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/snippet/%s", i.ServiceID, i.Version, i.SnippetName)
+	path := fmt.Sprintf("/service/%s/version/%d/snippet/%s", i.Service, i.Version, i.SnippetName)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -270,8 +270,8 @@ func (c *Client) GetSnippet(i *GetSnippetInput) (*Snippet, error) {
 
 // GetDynamicSnippetInput is used as input to the GetDynamicSnippet function.
 type GetDynamicSnippetInput struct {
-	// ServiceID is the ID of the service.
-	ServiceID string
+	// Service is the ID of the service.
+	Service string
 
 	// SnippetID is the ID of the Snippet to fetch.
 	SnippetID string
@@ -280,15 +280,15 @@ type GetDynamicSnippetInput struct {
 // GetDynamicSnippet gets the Snippet configuration with the given parameters. This will show the current content
 // associated with a Dynamic Snippet.
 func (c *Client) GetDynamicSnippet(i *GetDynamicSnippetInput) (*DynamicSnippet, error) {
-	if i.ServiceID == "" {
-		return nil, ErrMissingServiceID
+	if i.Service == "" {
+		return nil, ErrMissingService
 	}
 
 	if i.SnippetID == "" {
 		return nil, ErrMissingSnippetID
 	}
 
-	path := fmt.Sprintf("/service/%s/snippet/%s", i.ServiceID, i.SnippetID)
+	path := fmt.Sprintf("/service/%s/snippet/%s", i.Service, i.SnippetID)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err

--- a/fastly/vcl_snippets_test.go
+++ b/fastly/vcl_snippets_test.go
@@ -50,7 +50,7 @@ func Test_Snippets(t *testing.T) {
 	var cs *Snippet
 	record(t, "vcl_snippets/create", func(c *Client) {
 		cs, err = c.CreateSnippet(&CreateSnippetInput{
-			ServiceID:   testServiceID,
+			Service:     testServiceID,
 			Version:     tv,
 			SnippetName: testSnippetName,
 			Type:        "recv",
@@ -64,7 +64,7 @@ func Test_Snippets(t *testing.T) {
 		t.Fatal(err)
 	}
 	if cs.ServiceID != testServiceID {
-		t.Errorf("bad serviceID: %q", cs.ServiceID)
+		t.Errorf("bad sID: %q", cs.ServiceID)
 	}
 	if cs.SnippetName != testSnippetName {
 		t.Errorf("bad name: %q", cs.SnippetName)
@@ -80,7 +80,7 @@ func Test_Snippets(t *testing.T) {
 	var cds *Snippet
 	record(t, "vcl_snippets/create_dyn", func(c *Client) {
 		cds, err = c.CreateSnippet(&CreateSnippetInput{
-			ServiceID:   testServiceID,
+			Service:     testServiceID,
 			Version:     tv,
 			SnippetName: testDynSnippetName,
 			Type:        "recv",
@@ -93,8 +93,8 @@ func Test_Snippets(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if cs.ServiceID != testServiceID {
-		t.Errorf("bad sID: %q", cs.ServiceID)
+	if cds.ServiceID != testServiceID {
+		t.Errorf("bad sID: %q", cds.ServiceID)
 	}
 	if cds.SnippetName != testDynSnippetName {
 		t.Errorf("bad name: %q", cds.SnippetName)
@@ -107,7 +107,7 @@ func Test_Snippets(t *testing.T) {
 	var uds *DynamicSnippet
 	record(t, "vcl_snippets/update", func(c *Client) {
 		uds, err = c.UpdateDynamicSnippet(&UpdateDynamicSnippetInput{
-			ServiceID: testServiceID,
+			Service:   testServiceID,
 			SnippetID: testDynSnippetID,
 			Content:   updatedDynContent,
 		})
@@ -123,7 +123,7 @@ func Test_Snippets(t *testing.T) {
 	// Delete
 	record(t, "vcl_snippets/delete", func(c *Client) {
 		err = c.DeleteSnippet(&DeleteSnippetInput{
-			ServiceID:   testServiceID,
+			Service:     testServiceID,
 			SnippetName: testDynSnippetName,
 			Version:     tv,
 		})
@@ -136,7 +136,7 @@ func Test_Snippets(t *testing.T) {
 	var ds *DynamicSnippet
 	record(t, "vcl_snippets/get_dynamic", func(c *Client) {
 		ds, err = c.GetDynamicSnippet(&GetDynamicSnippetInput{
-			ServiceID: testServiceID,
+			Service:   testServiceID,
 			SnippetID: testDynSnippetID,
 		})
 
@@ -155,7 +155,7 @@ func Test_Snippets(t *testing.T) {
 	var gs *Snippet
 	record(t, "vcl_snippets/get", func(c *Client) {
 		gs, err = c.GetSnippet(&GetSnippetInput{
-			ServiceID:   testServiceID,
+			Service:     testServiceID,
 			SnippetName: testSnippetName,
 			Version:     tv,
 		})
@@ -168,7 +168,7 @@ func Test_Snippets(t *testing.T) {
 		t.Errorf("bad name: %q", gs.SnippetName)
 	}
 	if gs.ServiceID != testServiceID {
-		t.Errorf("bad sID: %q", gs.ServiceID)
+		t.Errorf("bad service: %q", gs.ServiceID)
 	}
 	if gs.Content != content {
 		t.Errorf("bad content: %q", gs.Content)
@@ -178,8 +178,8 @@ func Test_Snippets(t *testing.T) {
 	var sl []*Snippet
 	record(t, "vcl_snippets/list", func(c *Client) {
 		sl, err = c.ListSnippets(&ListSnippetsInput{
-			ServiceID: testServiceID,
-			Version:   tv,
+			Service: testServiceID,
+			Version: tv,
 		})
 
 	})
@@ -188,7 +188,7 @@ func Test_Snippets(t *testing.T) {
 	}
 	for _, x := range sl {
 		if x.ServiceID != testServiceID {
-			t.Errorf("bad sID: %q", x.ServiceID)
+			t.Errorf("bad service: %q", x.ServiceID)
 		}
 		if x.Version != tv {
 			t.Errorf("bad Version: %q", x.Version)
@@ -196,13 +196,13 @@ func Test_Snippets(t *testing.T) {
 	}
 
 	_, err = testClient.GetDynamicSnippet(&GetDynamicSnippetInput{
-		ServiceID: "",
+		Service: "",
 	})
-	if err != ErrMissingServiceID {
+	if err != ErrMissingService {
 		t.Errorf("bad error: %s", err)
 	}
 	_, err = testClient.GetDynamicSnippet(&GetDynamicSnippetInput{
-		ServiceID: testServiceID,
+		Service:   testServiceID,
 		SnippetID: "",
 	})
 	if err != ErrMissingSnippetID {
@@ -210,7 +210,7 @@ func Test_Snippets(t *testing.T) {
 	}
 
 	_, err = testClient.CreateSnippet(&CreateSnippetInput{
-		ServiceID:   testServiceID,
+		Service:     testServiceID,
 		Version:     tv,
 		SnippetName: testSnippetName,
 		Type:        "recv",


### PR DESCRIPTION
Sadly a breaking change, but makes this new VCL Snippet type consistent with all the other API Input's in this lib that use "Service" instead of "ServiceID".