### PR TITLE
A few small tweaks to make consistent with the rest of the API

### DIFF
--- a/fastly/errors.go
+++ b/fastly/errors.go
@@ -25,32 +25,20 @@ var ErrMissingTag = errors.New("Missing required field 'Tag'")
 // a "Version" key, but one was not set.
 var ErrMissingVersion = errors.New("Missing required field 'Version'")
 
-// ErrMissingSnippetID is an error that is returned when an input struct requires
-// a "SnippetID" key, but one was not set.
-var ErrMissingSnippetID = errors.New("Missing required field 'SnippetID'")
-
-// ErrMissingSnippetName is an error that is returned when an input struct requires
-// a "SnippetID" key, but one was not set.
-var ErrMissingSnippetName = errors.New("Missing required field 'SnippetName'")
-
-// ErrMissingSnippetContent s an error that is returned when an input struct requires a
+// ErrMissingContent is an error that is returned when an input struct requires a
 // "Content" key, but one was not set.
-var ErrMissingSnippetContent = errors.New("Missing required content for a non-Dynamic Snippet")
-
-// ErrMissingSnippetType s an error that is returned when an input struct requires a
-// "Type" key, but one was not set.
-var ErrMissingSnippetType = errors.New("Missing required field 'Type'")
+var ErrMissingContent = errors.New("Missing required field 'Content'")
 
 // ErrMissingName is an error that is returned when an input struct requires a
 // "Name" key, but one was not set.
 var ErrMissingName = errors.New("Missing required field 'Name'")
 
 // ErrMissingKey is an error that is returned when an input struct requires a
-// "Name" key, but one was not set.
+// "Key" key, but one was not set.
 var ErrMissingKey = errors.New("Missing required field 'Key'")
 
 // ErrMissingURL is an error that is returned when an input struct requires a
-// "Name" key, but one was not set.
+// "URL" key, but one was not set.
 var ErrMissingURL = errors.New("Missing required field 'URL'")
 
 // ErrMissingID is an error that is returned when an input struct requires an

--- a/fastly/vcl_snippets_test.go
+++ b/fastly/vcl_snippets_test.go
@@ -50,13 +50,13 @@ func Test_Snippets(t *testing.T) {
 	var cs *Snippet
 	record(t, "vcl_snippets/create", func(c *Client) {
 		cs, err = c.CreateSnippet(&CreateSnippetInput{
-			Service:     testServiceID,
-			Version:     tv,
-			SnippetName: testSnippetName,
-			Type:        "recv",
-			Priority:    100,
-			Dynamic:     0,
-			Content:     content,
+			Service:  testServiceID,
+			Version:  tv,
+			Name:     testSnippetName,
+			Type:     SnippetTypeRecv,
+			Priority: 100,
+			Dynamic:  0,
+			Content:  content,
 		})
 	})
 
@@ -66,10 +66,10 @@ func Test_Snippets(t *testing.T) {
 	if cs.ServiceID != testServiceID {
 		t.Errorf("bad sID: %q", cs.ServiceID)
 	}
-	if cs.SnippetName != testSnippetName {
-		t.Errorf("bad name: %q", cs.SnippetName)
+	if cs.Name != testSnippetName {
+		t.Errorf("bad name: %q", cs.Name)
 	}
-	if cs.Type != "recv" {
+	if cs.Type != SnippetTypeRecv {
 		t.Errorf("bad type: %q", cs.Type)
 	}
 	if cs.Content != content {
@@ -80,13 +80,13 @@ func Test_Snippets(t *testing.T) {
 	var cds *Snippet
 	record(t, "vcl_snippets/create_dyn", func(c *Client) {
 		cds, err = c.CreateSnippet(&CreateSnippetInput{
-			Service:     testServiceID,
-			Version:     tv,
-			SnippetName: testDynSnippetName,
-			Type:        "recv",
-			Priority:    100,
-			Dynamic:     1,
-			Content:     dynContent,
+			Service:  testServiceID,
+			Version:  tv,
+			Name:     testDynSnippetName,
+			Type:     SnippetTypeRecv,
+			Priority: 100,
+			Dynamic:  1,
+			Content:  dynContent,
 		})
 	})
 
@@ -96,10 +96,10 @@ func Test_Snippets(t *testing.T) {
 	if cds.ServiceID != testServiceID {
 		t.Errorf("bad sID: %q", cds.ServiceID)
 	}
-	if cds.SnippetName != testDynSnippetName {
-		t.Errorf("bad name: %q", cds.SnippetName)
+	if cds.Name != testDynSnippetName {
+		t.Errorf("bad name: %q", cds.Name)
 	}
-	if cds.Type != "recv" {
+	if cds.Type != SnippetTypeRecv {
 		t.Errorf("bad type: %q", cds.Type)
 	}
 
@@ -107,9 +107,9 @@ func Test_Snippets(t *testing.T) {
 	var uds *DynamicSnippet
 	record(t, "vcl_snippets/update", func(c *Client) {
 		uds, err = c.UpdateDynamicSnippet(&UpdateDynamicSnippetInput{
-			Service:   testServiceID,
-			SnippetID: testDynSnippetID,
-			Content:   updatedDynContent,
+			Service: testServiceID,
+			ID:      testDynSnippetID,
+			Content: updatedDynContent,
 		})
 	})
 	if err != nil {
@@ -123,9 +123,9 @@ func Test_Snippets(t *testing.T) {
 	// Delete
 	record(t, "vcl_snippets/delete", func(c *Client) {
 		err = c.DeleteSnippet(&DeleteSnippetInput{
-			Service:     testServiceID,
-			SnippetName: testDynSnippetName,
-			Version:     tv,
+			Service: testServiceID,
+			Name:    testDynSnippetName,
+			Version: tv,
 		})
 	})
 	if err != nil {
@@ -136,8 +136,8 @@ func Test_Snippets(t *testing.T) {
 	var ds *DynamicSnippet
 	record(t, "vcl_snippets/get_dynamic", func(c *Client) {
 		ds, err = c.GetDynamicSnippet(&GetDynamicSnippetInput{
-			Service:   testServiceID,
-			SnippetID: testDynSnippetID,
+			Service: testServiceID,
+			ID:      testDynSnippetID,
 		})
 
 	})
@@ -147,25 +147,25 @@ func Test_Snippets(t *testing.T) {
 	if ds.ServiceID != testServiceID {
 		t.Errorf("bad sID: %q", ds.ServiceID)
 	}
-	if ds.SnippetID != testDynSnippetID {
-		t.Errorf("bad snipID: %q", ds.SnippetID)
+	if ds.ID != testDynSnippetID {
+		t.Errorf("bad snipID: %q", ds.ID)
 	}
 
 	// GETSnippet
 	var gs *Snippet
 	record(t, "vcl_snippets/get", func(c *Client) {
 		gs, err = c.GetSnippet(&GetSnippetInput{
-			Service:     testServiceID,
-			SnippetName: testSnippetName,
-			Version:     tv,
+			Service: testServiceID,
+			Name:    testSnippetName,
+			Version: tv,
 		})
 
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if gs.SnippetName != testSnippetName {
-		t.Errorf("bad name: %q", gs.SnippetName)
+	if gs.Name != testSnippetName {
+		t.Errorf("bad name: %q", gs.Name)
 	}
 	if gs.ServiceID != testServiceID {
 		t.Errorf("bad service: %q", gs.ServiceID)
@@ -202,24 +202,24 @@ func Test_Snippets(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 	_, err = testClient.GetDynamicSnippet(&GetDynamicSnippetInput{
-		Service:   testServiceID,
-		SnippetID: "",
+		Service: testServiceID,
+		ID:      "",
 	})
-	if err != ErrMissingSnippetID {
+	if err != ErrMissingID {
 		t.Errorf("bad error: %s", err)
 	}
 
 	_, err = testClient.CreateSnippet(&CreateSnippetInput{
-		Service:     testServiceID,
-		Version:     tv,
-		SnippetName: testSnippetName,
-		Type:        "recv",
-		Priority:    100,
-		Dynamic:     0,
-		Content:     "",
+		Service:  testServiceID,
+		Version:  tv,
+		Name:     testSnippetName,
+		Type:     SnippetTypeRecv,
+		Priority: 100,
+		Dynamic:  0,
+		Content:  "",
 	})
 
-	if err != ErrMissingSnippetContent {
+	if err != ErrMissingContent {
 		t.Errorf("bad error: %s", err)
 	}
 }


### PR DESCRIPTION
Sorry, more breaking changes for VCL Snippets... :(

* Make Snippet `Type` its own type vs a string (like Headers, Cache and Request settings)
* `SnippetName` -> `Name`
* `SnippetID` -> `ID` (like ACL's, though the underlying Fastly API is `snippet_id` for Dynamic Snippets)

Also use some of the pre-existing, generic error types rather than creating ones specific to Snippets.