### PR TITLE
Add a few missing fields to some API's

### DIFF
--- a/fastly/acl.go
+++ b/fastly/acl.go
@@ -11,6 +11,10 @@ type ACL struct {
 
 	Name string `mapstructure:"name"`
 	ID   string `mapstructure:"id"`
+
+	DeletedAt string `mapstructure:"deleted_at"`
+	CreatedAt string `mapstructure:"created_at"`
+	UpdatedAt string `mapstructure:"updated_at"`
 }
 
 // ACLsByName is a sortable list of ACLs.

--- a/fastly/acl_entry.go
+++ b/fastly/acl_entry.go
@@ -14,6 +14,10 @@ type ACLEntry struct {
 	Subnet  string `mapstructure:"subnet"`
 	Negated bool   `mapstructure:"negated"`
 	Comment string `mapstructure:"comment"`
+
+	DeletedAt string `mapstructure:"deleted_at"`
+	CreatedAt string `mapstructure:"created_at"`
+	UpdatedAt string `mapstructure:"updated_at"`
 }
 
 // entriesById is a sortable list of ACL entries.

--- a/fastly/backend.go
+++ b/fastly/backend.go
@@ -11,6 +11,7 @@ type Backend struct {
 	Version   int    `mapstructure:"version"`
 
 	Name                string   `mapstructure:"name"`
+	Comment             string   `mapstructure:"comment"`
 	Address             string   `mapstructure:"address"`
 	Port                uint     `mapstructure:"port"`
 	ConnectTimeout      uint     `mapstructure:"connect_timeout"`
@@ -88,6 +89,7 @@ type CreateBackendInput struct {
 	Version int
 
 	Name                string       `form:"name,omitempty"`
+	Comment             string       `form:"comment,omitempty"`
 	Address             string       `form:"address,omitempty"`
 	Port                uint         `form:"port,omitempty"`
 	ConnectTimeout      uint         `form:"connect_timeout,omitempty"`
@@ -185,6 +187,7 @@ type UpdateBackendInput struct {
 	Name string
 
 	NewName             string       `form:"name,omitempty"`
+	Comment             string       `form:"comment,omitempty"`
 	Address             string       `form:"address,omitempty"`
 	Port                uint         `form:"port,omitempty"`
 	ConnectTimeout      uint         `form:"connect_timeout,omitempty"`

--- a/fastly/condition.go
+++ b/fastly/condition.go
@@ -12,6 +12,7 @@ type Condition struct {
 	Version   int    `mapstructure:"version"`
 
 	Name      string `mapstructure:"name"`
+	Comment   string `mapstructure:"comment"`
 	Statement string `mapstructure:"statement"`
 	Type      string `mapstructure:"type"`
 	Priority  int    `mapstructure:"priority"`
@@ -144,6 +145,8 @@ type UpdateConditionInput struct {
 	// Name is the name of the condition to update.
 	Name string
 
+	NewName   string `form:"name,omitempty"`
+	Comment   string `form:"comment,omitempty"`
 	Statement string `form:"statement,omitempty"`
 	Type      string `form:"type,omitempty"`
 	Priority  int    `form:"priority,omitempty"`

--- a/fastly/condition_test.go
+++ b/fastly/condition_test.go
@@ -98,6 +98,7 @@ func TestClient_Conditions(t *testing.T) {
 			Service:   testServiceID,
 			Version:   tv.Number,
 			Name:      "test/condition",
+			NewName:   "new-test/condition",
 			Statement: "req.url~+\"updated.html\"",
 		})
 	})

--- a/fastly/dictionary.go
+++ b/fastly/dictionary.go
@@ -82,7 +82,8 @@ type CreateDictionaryInput struct {
 	Service string
 	Version int
 
-	Name string `form:"name,omitempty"`
+	Name      string       `form:"name,omitempty"`
+	WriteOnly *Compatibool `form:"write_only,omitempty"`
 }
 
 // CreateDictionary creates a new Fastly dictionary.
@@ -156,7 +157,8 @@ type UpdateDictionaryInput struct {
 	// Name is the name of the dictionary to update.
 	Name string
 
-	NewName string `form:"name,omitempty"`
+	NewName   string       `form:"name,omitempty"`
+	WriteOnly *Compatibool `form:"write_only,omitempty"`
 }
 
 // UpdateDictionary updates a specific dictionary.

--- a/fastly/director.go
+++ b/fastly/director.go
@@ -29,10 +29,15 @@ type Director struct {
 
 	Name     string       `mapstructure:"name"`
 	Comment  string       `mapstructure:"comment"`
+	Shield   string       `mapstructure:"shield"`
 	Quorum   uint         `mapstructure:"quorum"`
 	Type     DirectorType `mapstructure:"type"`
 	Retries  uint         `mapstructure:"retries"`
 	Capacity uint         `mapstructure:"capacity"`
+
+	DeletedAt string `mapstructure:"deleted_at"`
+	CreatedAt string `mapstructure:"created_at"`
+	UpdatedAt string `mapstructure:"updated_at"`
 }
 
 // directorsByName is a sortable list of directors.
@@ -85,11 +90,13 @@ type CreateDirectorInput struct {
 	Service string
 	Version int
 
-	Name    string       `form:"name,omitempty"`
-	Comment string       `form:"comment,omitempty"`
-	Quorum  uint         `form:"quorum,omitempty"`
-	Type    DirectorType `form:"type,omitempty"`
-	Retries uint         `form:"retries,omitempty"`
+	Name     string       `form:"name,omitempty"`
+	Comment  string       `form:"comment,omitempty"`
+	Shield   string       `form:"shield,omitempty"`
+	Quorum   uint         `form:"quorum,omitempty"`
+	Type     DirectorType `form:"type,omitempty"`
+	Retries  uint         `form:"retries,omitempty"`
+	Capacity uint         `form:"capacity,omitempty"`
 }
 
 // CreateDirector creates a new Fastly director.
@@ -163,10 +170,13 @@ type UpdateDirectorInput struct {
 	// Name is the name of the director to update.
 	Name string
 
-	Comment string       `form:"comment,omitempty"`
-	Quorum  uint         `form:"quorum,omitempty"`
-	Type    DirectorType `form:"type,omitempty"`
-	Retries uint         `form:"retries,omitempty"`
+	NewName  string       `form:"name,omitempty"`
+	Comment  string       `form:"comment,omitempty"`
+	Shield   string       `form:"shield,omitempty"`
+	Quorum   uint         `form:"quorum,omitempty"`
+	Type     DirectorType `form:"type,omitempty"`
+	Retries  uint         `form:"retries,omitempty"`
+	Capacity uint         `form:"capacity,omitempty"`
 }
 
 // UpdateDirector updates a specific director.

--- a/fastly/director_test.go
+++ b/fastly/director_test.go
@@ -104,6 +104,7 @@ func TestClient_Directors(t *testing.T) {
 			Service: testServiceID,
 			Version: tv.Number,
 			Name:    "test-director",
+			NewName: "new-test-director",
 			Quorum:  100,
 		})
 	})

--- a/fastly/domain.go
+++ b/fastly/domain.go
@@ -12,7 +12,6 @@ type Domain struct {
 
 	Name    string `mapstructure:"name"`
 	Comment string `mapstructure:"comment"`
-	Locked  bool   `mapstructure:"locked"`
 }
 
 // domainsByName is a sortable list of backends.

--- a/fastly/health_check.go
+++ b/fastly/health_check.go
@@ -11,6 +11,7 @@ type HealthCheck struct {
 	Version   int    `mapstructure:"version"`
 
 	Name             string `mapstructure:"name"`
+	Comment          string `mapstructure:"comment"`
 	Method           string `mapstructure:"method"`
 	Host             string `mapstructure:"host"`
 	Path             string `mapstructure:"path"`
@@ -75,6 +76,7 @@ type CreateHealthCheckInput struct {
 	Version int
 
 	Name             string `form:"name,omitempty"`
+	Comment          string `form:"comment,omitempty"`
 	Method           string `form:"method,omitempty"`
 	Host             string `form:"host,omitempty"`
 	Path             string `form:"path,omitempty"`
@@ -159,6 +161,7 @@ type UpdateHealthCheckInput struct {
 	Name string
 
 	NewName          string `form:"name,omitempty"`
+	Comment          string `form:"comment,omitempty"`
 	Method           string `form:"method,omitempty"`
 	Host             string `form:"host,omitempty"`
 	Path             string `form:"path,omitempty"`


### PR DESCRIPTION
* The CreateDirectorInput and UpdateDirectorInput were missing the
`capacity` field, added the `shield` field.

* Added `name` (NewName) to UpdateDirectorInput, UpdateConditionInput

* Added `write_only` bool to CreateDictionary/UpdateDictionary

* Added `comment` to various, and created_at/deleted_at/updated_at to
  those that support it (eg; those that can be updated dynamically).

* Removed `locked` from Domain (looks like a copypasta from elsewhere?)