### PR TITLE
Added log placement support for integrations that were missing it

### DIFF
--- a/fastly/gcs.go
+++ b/fastly/gcs.go
@@ -84,6 +84,7 @@ type CreateGCSInput struct {
 	MessageType       string `form:"message_type,omitempty"`
 	ResponseCondition string `form:"response_condition,omitempty"`
 	TimestampFormat   string `form:"timestamp_format,omitempty"`
+	Placement         string `form:"placement,omitempty"`
 }
 
 // CreateGCS creates a new Fastly GCS.

--- a/fastly/s3.go
+++ b/fastly/s3.go
@@ -101,7 +101,7 @@ type CreateS3Input struct {
 	ResponseCondition string       `form:"response_condition,omitempty"`
 	TimestampFormat   string       `form:"timestamp_format,omitempty"`
 	Redundancy        S3Redundancy `form:"redundancy,omitempty"`
-        Placement         string       `form:"placement,omitempty"`
+	Placement         string       `form:"placement,omitempty"`
 }
 
 // CreateS3 creates a new Fastly S3.

--- a/fastly/sumologic.go
+++ b/fastly/sumologic.go
@@ -21,6 +21,7 @@ type Sumologic struct {
 	CreatedAt         *time.Time `mapstructure:"created_at"`
 	UpdatedAt         *time.Time `mapstructure:"updated_at"`
 	DeletedAt         *time.Time `mapstructure:"deleted_at"`
+	
 }
 
 // sumologicsByName is a sortable list of sumologics.


### PR DESCRIPTION
Adding placement support is key to allow WAF events through those specific integration. More information on how the placement parameter is used can be found at: https://docs.fastly.com/guides/web-application-firewall/fastly-waf-logging#waf_debug_log 