### PR TITLE
Adds getting a list of domains for service_id 

### DIFF
--- a/fastly/fixtures/services/domain.yaml
+++ b/fastly/fixtures/services/domain.yaml
@@ -1,0 +1,64 @@
+---
+version: 1
+rwmutex: {}
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Fastly-Key:
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      User-Agent:
+      - FastlyGo/0.4.3.dev (+github.com/sethvargo/go-fastly; go1.10.1)
+    url: https://api.fastly.com/service/6cqczz91loS2dnXX5w9UIC/domain
+    method: GET
+  response:
+    body: '[
+    {
+        "locked": true,
+        "version": 1,
+        "name": "abc.com",
+        "deleted_at": null,
+        "service_id": "6cqczz91loS2dnXX5w9UIC",
+        "created_at": "2017-05-06T04:53:04Z",
+        "comment": "",
+        "updated_at": "2017-05-06T04:53:04Z"
+    },
+    {
+        "locked": true,
+        "version": 1,
+        "name": "def.com",
+        "deleted_at": null,
+        "service_id": "6cqczz91loS2dnXX5w9UIC",
+        "created_at": "2017-05-07T05:28:19Z",
+        "comment": "",
+        "updated_at": "2017-05-07T05:28:19Z"
+    }]'
+    headers:
+      Accept-Ranges:
+      - bytes
+      - bytes
+      - bytes
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 14 Oct 2018 21:50:04 GMT
+      Status:
+      - 200 OK
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lax8630-LAX
+      X-Timer:
+      - S1539553804.712884,VS0,VE332
+    status: 200 OK
+    code: 200

--- a/fastly/service.go
+++ b/fastly/service.go
@@ -224,8 +224,8 @@ type ListServiceDomainInput struct {
 	ID string
 }
 
-// ListDomain lists all domains associated with a given service
-func (c *Client) ListDomain(i *ListServiceDomainInput) (ServiceDomainsList, error) {
+// ListServiceDomains lists all domains associated with a given service
+func (c *Client) ListServiceDomains(i *ListServiceDomainInput) (ServiceDomainsList, error) {
 	if i.ID == "" {
 		return nil, ErrMissingID
 	}

--- a/fastly/service.go
+++ b/fastly/service.go
@@ -220,16 +220,15 @@ func (c *Client) SearchService(i *SearchServiceInput) (*Service, error) {
 	return s, nil
 }
 
-type ListServiceDomainInput struct{
+type ListServiceDomainInput struct {
 	ID string
 }
 
-
+// ListDomain lists all domains associated with a given service
 func (c *Client) ListDomain(i *ListServiceDomainInput) (ServiceDomainsList, error) {
 	if i.ID == "" {
 		return nil, ErrMissingID
 	}
-
 	path := fmt.Sprintf("/service/%s/domain", i.ID)
 	resp, err := c.Get(path, nil)
 	if err != nil {
@@ -237,6 +236,7 @@ func (c *Client) ListDomain(i *ListServiceDomainInput) (ServiceDomainsList, erro
 	}
 
 	var ds ServiceDomainsList
+
 	if err := decodeJSON(&ds, resp.Body); err != nil {
 		return nil, err
 	}

--- a/fastly/service.go
+++ b/fastly/service.go
@@ -3,6 +3,7 @@ package fastly
 import (
 	"fmt"
 	"sort"
+	"time"
 )
 
 // Service represents a single service for the Fastly account.
@@ -27,6 +28,18 @@ type ServiceDetail struct {
 	Version       Version    `mapstructure:"version"`
 	Versions      []*Version `mapstructure:"versions"`
 }
+
+type ServiceDomain struct {
+	Locked    bool       `mapstructure:"locked"`
+	Version   int64      `mapstructure:"version"`
+	Name      string     `mapstructure:"name"`
+	DeletedAt *time.Time `mapstructure:"deleted_at"`
+	ServiceID string     `mapstructure: "service_id"`
+	CreatedAt time.Time  `mapstructure: "created_at"`
+	Comment   string     `mapstructure:"comment"`
+	UpdatedAt time.Time  `mapstructure:"updated_at"`
+}
+type ServiceDomainsList []*ServiceDomain
 
 // servicesByName is a sortable list of services.
 type servicesByName []*Service
@@ -205,4 +218,28 @@ func (c *Client) SearchService(i *SearchServiceInput) (*Service, error) {
 	}
 
 	return s, nil
+}
+
+type ListServiceDomainInput struct{
+	ID string
+}
+
+
+func (c *Client) ListDomain(i *ListServiceDomainInput) (ServiceDomainsList, error) {
+	if i.ID == "" {
+		return nil, ErrMissingID
+	}
+
+	path := fmt.Sprintf("/service/%s/domain", i.ID)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var ds ServiceDomainsList
+	if err := decodeJSON(&ds, resp.Body); err != nil {
+		return nil, err
+	}
+
+	return ds, nil
 }

--- a/fastly/service_test.go
+++ b/fastly/service_test.go
@@ -142,6 +142,21 @@ func TestClient_Services(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	//	List Domains
+	var ds ServiceDomainsList
+	record(t, "services/domain", func(c *Client) {
+		ds, err = c.ListDomain(&ListServiceDomainInput{
+			ID: s.ID,
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ds) < 1 {
+		t.Fatal("bad services: %v", ds)
+	}
+
 }
 
 func TestClient_GetService_validation(t *testing.T) {

--- a/fastly/service_test.go
+++ b/fastly/service_test.go
@@ -156,7 +156,6 @@ func TestClient_Services(t *testing.T) {
 	if len(ds) < 1 {
 		t.Fatal("bad services: %v", ds)
 	}
-
 }
 
 func TestClient_GetService_validation(t *testing.T) {

--- a/fastly/service_test.go
+++ b/fastly/service_test.go
@@ -146,7 +146,7 @@ func TestClient_Services(t *testing.T) {
 	//	List Domains
 	var ds ServiceDomainsList
 	record(t, "services/domain", func(c *Client) {
-		ds, err = c.ListDomain(&ListServiceDomainInput{
+		ds, err = c.ListServiceDomains(&ListServiceDomainInput{
 			ID: s.ID,
 		})
 	})


### PR DESCRIPTION
This adds an additional method to call the `/service/SERVICE_ID/domain` endpoint to retrieve a list of domains for a given Service ID. Corresponding endpoint and documentation here: https://docs.fastly.com/api/config#service_d5578a1e3bc75512711ddd0a58ce7a36