### PR TITLE
add Main attribute to CreateVCLInput

### DIFF
--- a/fastly/vcl.go
+++ b/fastly/vcl.go
@@ -136,6 +136,7 @@ type CreateVCLInput struct {
 
 	Name    string `form:"name,omitempty"`
 	Content string `form:"content,omitempty"`
+	Main    bool   `form:"main,omitempty"`
 }
 
 // CreateVCL creates a new Fastly VCL.


### PR DESCRIPTION
This PR adds `Main` attribute to the `CreateVCLInput` struct so that it allows you to create a new VCL object as a main VCL rather than creating it as non-main and then set to main with a separate request.

https://docs.fastly.com/api/config#vcl 
> main | boolean | Set to true when this is the main VCL, otherwise false


