### PR TITLE
Update waf and other fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ sudo: false
 language: go
 
 go:
-  - 1.8
+  - "1.10"
+  - "1.11"
 
 branches:
   only:

--- a/fastly/realtime_stats_test.go
+++ b/fastly/realtime_stats_test.go
@@ -18,9 +18,8 @@ func TestStatsClient_GetRealtimeStats(t *testing.T) {
 	var err error
 
 	// Get
-	var s *RealtimeStatsResponse
 	recordRealtimeStats(t, "realtime_stats/get", func(c *RTSClient) {
-		s, err = c.GetRealtimeStats(&GetRealtimeStatsInput{
+		_, err = c.GetRealtimeStats(&GetRealtimeStatsInput{
 			Service:   testServiceID,
 			Timestamp: 0,
 			Limit:     3,

--- a/fastly/service_test.go
+++ b/fastly/service_test.go
@@ -154,7 +154,7 @@ func TestClient_Services(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(ds) < 1 {
-		t.Fatal("bad services: %v", ds)
+		t.Fatalf("bad services: %v", ds)
 	}
 }
 

--- a/fastly/stats_test.go
+++ b/fastly/stats_test.go
@@ -6,9 +6,8 @@ func TestClient_GetStats(t *testing.T) {
 	t.Parallel()
 
 	var err error
-	var r *StatsResponse
 	record(t, "stats/service_stats", func(c *Client) {
-		r, err = c.GetStats(&GetStatsInput{
+		_, err = c.GetStats(&GetStatsInput{
 			Service: testServiceID,
 			From:    "10 days ago",
 			To:      "now",
@@ -26,9 +25,8 @@ func TestClient_GetRegions(t *testing.T) {
 	t.Parallel()
 
 	var err error
-	var r *RegionsResponse
 	record(t, "stats/regions", func(c *Client) {
-		r, err = c.GetRegions()
+		_, err = c.GetRegions()
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -39,9 +37,8 @@ func TestClient_GetRegionsUsage(t *testing.T) {
 	t.Parallel()
 
 	var err error
-	var r *UsageResponse
 	record(t, "stats/regions_usage", func(c *Client) {
-		r, err = c.GetUsage(&GetUsageInput{
+		_, err = c.GetUsage(&GetUsageInput{
 			From:   "10 days ago",
 			To:     "now",
 			By:     "minute",
@@ -57,9 +54,8 @@ func TestClient_GetServicesByRegionsUsage(t *testing.T) {
 	t.Parallel()
 
 	var err error
-	var r *UsageByServiceResponse
 	record(t, "stats/services_usage", func(c *Client) {
-		r, err = c.GetUsageByService(&GetUsageInput{
+		_, err = c.GetUsageByService(&GetUsageInput{
 			From:   "10 days ago",
 			To:     "now",
 			By:     "minute",

--- a/fastly/waf.go
+++ b/fastly/waf.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/google/jsonapi"
 )
@@ -21,11 +22,11 @@ type WAFConfigurationSet struct {
 
 // WAF is the information about a firewall object.
 type WAF struct {
-	ID                string `jsonapi:"primary,waf"`
-	Version           int    `jsonapi:"attr,version"`
-	PrefetchCondition string `jsonapi:"attr,prefetch_condition"`
-	Response          string `jsonapi:"attr,response"`
-	LastPush          string `jsonapi:"attr,last_push"`
+	ID                string     `jsonapi:"primary,waf"`
+	Version           int        `jsonapi:"attr,version"`
+	PrefetchCondition string     `jsonapi:"attr,prefetch_condition"`
+	Response          string     `jsonapi:"attr,response"`
+	LastPush          *time.Time `jsonapi:"attr,last_push,iso8601"`
 
 	ConfigurationSet *WAFConfigurationSet `jsonapi:"relation,configuration_set"`
 }
@@ -217,37 +218,37 @@ func (c *Client) DeleteWAF(i *DeleteWAFInput) error {
 
 // OWASP is the information about an OWASP object.
 type OWASP struct {
-	ID                               string `jsonapi:"primary,owasp"`
-	AllowedHTTPVersions              string `jsonapi:"attr,allowed_http_versions"`
-	AllowedMethods                   string `jsonapi:"attr,allowed_methods"`
-	AllowedRequestContentType        string `jsonapi:"attr,allowed_request_content_type"`
-	AllowedRequestContentTypeCharset string `jsonapi:"attr,allowed_request_content_type_charset"`
-	ArgLength                        int    `jsonapi:"attr,arg_length"`
-	ArgNameLength                    int    `jsonapi:"attr,arg_name_length"`
-	CombinedFileSizes                int    `jsonapi:"attr,combined_file_sizes"`
-	CreatedAt                        string `jsonapi:"attr,created_at"`
-	CriticalAnomalyScore             int    `jsonapi:"attr,critical_anomaly_score"`
-	CRSValidateUTF8Encoding          bool   `jsonapi:"attr,crs_validate_utf8_encoding"`
-	ErrorAnomalyScore                int    `jsonapi:"attr,error_anomaly_score"`
-	HighRiskCountryCodes             string `jsonapi:"attr,high_risk_country_codes"`
-	HTTPViolationScoreThreshold      int    `jsonapi:"attr,http_violation_score_threshold"`
-	InboundAnomalyScoreThreshold     int    `jsonapi:"attr,inbound_anomaly_score_threshold"`
-	LFIScoreThreshold                int    `jsonapi:"attr,lfi_score_threshold"`
-	MaxFileSize                      int    `jsonapi:"attr,max_file_size"`
-	MaxNumArgs                       int    `jsonapi:"attr,max_num_args"`
-	NoticeAnomalyScore               int    `jsonapi:"attr,notice_anomaly_score"`
-	ParanoiaLevel                    int    `jsonapi:"attr,paranoia_level"`
-	PHPInjectionScoreThreshold       int    `jsonapi:"attr,php_injection_score_threshold"`
-	RCEScoreThreshold                int    `jsonapi:"attr,rce_score_threshold"`
-	RestrictedExtensions             string `jsonapi:"attr,restricted_extensions"`
-	RestrictedHeaders                string `jsonapi:"attr,restricted_headers"`
-	RFIScoreThreshold                int    `jsonapi:"attr,rfi_score_threshold"`
-	SessionFixationScoreThreshold    int    `jsonapi:"attr,session_fixation_score_threshold"`
-	SQLInjectionScoreThreshold       int    `jsonapi:"attr,sql_injection_score_threshold"`
-	TotalArgLength                   int    `jsonapi:"attr,total_arg_length"`
-	UpdatedAt                        string `jsonapi:"attr,updated_at"`
-	WarningAnomalyScore              int    `jsonapi:"attr,warning_anomaly_score"`
-	XSSScoreThreshold                int    `jsonapi:"attr,xss_score_threshold"`
+	ID                               string     `jsonapi:"primary,owasp"`
+	AllowedHTTPVersions              string     `jsonapi:"attr,allowed_http_versions"`
+	AllowedMethods                   string     `jsonapi:"attr,allowed_methods"`
+	AllowedRequestContentType        string     `jsonapi:"attr,allowed_request_content_type"`
+	AllowedRequestContentTypeCharset string     `jsonapi:"attr,allowed_request_content_type_charset"`
+	ArgLength                        int        `jsonapi:"attr,arg_length"`
+	ArgNameLength                    int        `jsonapi:"attr,arg_name_length"`
+	CombinedFileSizes                int        `jsonapi:"attr,combined_file_sizes"`
+	CreatedAt                        *time.Time `jsonapi:"attr,created_at,iso8601"`
+	CriticalAnomalyScore             int        `jsonapi:"attr,critical_anomaly_score"`
+	CRSValidateUTF8Encoding          bool       `jsonapi:"attr,crs_validate_utf8_encoding"`
+	ErrorAnomalyScore                int        `jsonapi:"attr,error_anomaly_score"`
+	HighRiskCountryCodes             string     `jsonapi:"attr,high_risk_country_codes"`
+	HTTPViolationScoreThreshold      int        `jsonapi:"attr,http_violation_score_threshold"`
+	InboundAnomalyScoreThreshold     int        `jsonapi:"attr,inbound_anomaly_score_threshold"`
+	LFIScoreThreshold                int        `jsonapi:"attr,lfi_score_threshold"`
+	MaxFileSize                      int        `jsonapi:"attr,max_file_size"`
+	MaxNumArgs                       int        `jsonapi:"attr,max_num_args"`
+	NoticeAnomalyScore               int        `jsonapi:"attr,notice_anomaly_score"`
+	ParanoiaLevel                    int        `jsonapi:"attr,paranoia_level"`
+	PHPInjectionScoreThreshold       int        `jsonapi:"attr,php_injection_score_threshold"`
+	RCEScoreThreshold                int        `jsonapi:"attr,rce_score_threshold"`
+	RestrictedExtensions             string     `jsonapi:"attr,restricted_extensions"`
+	RestrictedHeaders                string     `jsonapi:"attr,restricted_headers"`
+	RFIScoreThreshold                int        `jsonapi:"attr,rfi_score_threshold"`
+	SessionFixationScoreThreshold    int        `jsonapi:"attr,session_fixation_score_threshold"`
+	SQLInjectionScoreThreshold       int        `jsonapi:"attr,sql_injection_score_threshold"`
+	TotalArgLength                   int        `jsonapi:"attr,total_arg_length"`
+	UpdatedAt                        *time.Time `jsonapi:"attr,updated_at,iso8601"`
+	WarningAnomalyScore              int        `jsonapi:"attr,warning_anomaly_score"`
+	XSSScoreThreshold                int        `jsonapi:"attr,xss_score_threshold"`
 }
 
 // GetOWASPInput is used as input to the GetOWASP function.
@@ -322,37 +323,37 @@ type UpdateOWASPInput struct {
 	ID      string
 	OWASPID string `jsonapi:"primary,owasp,omitempty"`
 
-	Type                             string `jsonapi:"attr,type"`
-	AllowedHTTPVersions              string `jsonapi:"attr,allowed_http_versions,omitempty"`
-	AllowedMethods                   string `jsonapi:"attr,allowed_methods,omitempty"`
-	AllowedRequestContentType        string `jsonapi:"attr,allowed_request_content_type,omitempty"`
-	AllowedRequestContentTypeCharset string `jsonapi:"attr,allowed_request_content_type_charset,omitempty"`
-	ArgLength                        int    `jsonapi:"attr,arg_length,omitempty"`
-	ArgNameLength                    int    `jsonapi:"attr,arg_name_length,omitempty"`
-	CombinedFileSizes                int    `jsonapi:"attr,combined_file_sizes,omitempty"`
-	CreatedAt                        string `jsonapi:"attr,created_at,omitempty"`
-	CriticalAnomalyScore             int    `jsonapi:"attr,critical_anomaly_score,omitempty"`
-	CRSValidateUTF8Encoding          bool   `jsonapi:"attr,crs_validate_utf8_encoding,omitempty"`
-	ErrorAnomalyScore                int    `jsonapi:"attr,error_anomaly_score,omitempty"`
-	HighRiskCountryCodes             string `jsonapi:"attr,high_risk_country_codes,omitempty"`
-	HTTPViolationScoreThreshold      int    `jsonapi:"attr,http_violation_score_threshold,omitempty"`
-	InboundAnomalyScoreThreshold     int    `jsonapi:"attr,inbound_anomaly_score_threshold,omitempty"`
-	LFIScoreThreshold                int    `jsonapi:"attr,lfi_score_threshold,omitempty"`
-	MaxFileSize                      int    `jsonapi:"attr,max_file_size,omitempty"`
-	MaxNumArgs                       int    `jsonapi:"attr,max_num_args,omitempty"`
-	NoticeAnomalyScore               int    `jsonapi:"attr,notice_anomaly_score,omitempty"`
-	ParanoiaLevel                    int    `jsonapi:"attr,paranoia_level,omitempty"`
-	PHPInjectionScoreThreshold       int    `jsonapi:"attr,php_injection_score_threshold,omitempty"`
-	RCEScoreThreshold                int    `jsonapi:"attr,rce_score_threshold,omitempty"`
-	RestrictedExtensions             string `jsonapi:"attr,restricted_extensions,omitempty"`
-	RestrictedHeaders                string `jsonapi:"attr,restricted_headers,omitempty"`
-	RFIScoreThreshold                int    `jsonapi:"attr,rfi_score_threshold,omitempty"`
-	SessionFixationScoreThreshold    int    `jsonapi:"attr,session_fixation_score_threshold,omitempty"`
-	SQLInjectionScoreThreshold       int    `jsonapi:"attr,sql_injection_score_threshold,omitempty"`
-	TotalArgLength                   int    `jsonapi:"attr,total_arg_length,omitempty"`
-	UpdatedAt                        string `jsonapi:"attr,updated_at,omitempty"`
-	WarningAnomalyScore              int    `jsonapi:"attr,warning_anomaly_score,omitempty"`
-	XSSScoreThreshold                int    `jsonapi:"attr,xss_score_threshold,omitempty"`
+	Type                             string     `jsonapi:"attr,type"`
+	AllowedHTTPVersions              string     `jsonapi:"attr,allowed_http_versions,omitempty"`
+	AllowedMethods                   string     `jsonapi:"attr,allowed_methods,omitempty"`
+	AllowedRequestContentType        string     `jsonapi:"attr,allowed_request_content_type,omitempty"`
+	AllowedRequestContentTypeCharset string     `jsonapi:"attr,allowed_request_content_type_charset,omitempty"`
+	ArgLength                        int        `jsonapi:"attr,arg_length,omitempty"`
+	ArgNameLength                    int        `jsonapi:"attr,arg_name_length,omitempty"`
+	CombinedFileSizes                int        `jsonapi:"attr,combined_file_sizes,omitempty"`
+	CreatedAt                        *time.Time `jsonapi:"attr,created_at,omitempty,iso8601"`
+	CriticalAnomalyScore             int        `jsonapi:"attr,critical_anomaly_score,omitempty"`
+	CRSValidateUTF8Encoding          bool       `jsonapi:"attr,crs_validate_utf8_encoding,omitempty"`
+	ErrorAnomalyScore                int        `jsonapi:"attr,error_anomaly_score,omitempty"`
+	HighRiskCountryCodes             string     `jsonapi:"attr,high_risk_country_codes,omitempty"`
+	HTTPViolationScoreThreshold      int        `jsonapi:"attr,http_violation_score_threshold,omitempty"`
+	InboundAnomalyScoreThreshold     int        `jsonapi:"attr,inbound_anomaly_score_threshold,omitempty"`
+	LFIScoreThreshold                int        `jsonapi:"attr,lfi_score_threshold,omitempty"`
+	MaxFileSize                      int        `jsonapi:"attr,max_file_size,omitempty"`
+	MaxNumArgs                       int        `jsonapi:"attr,max_num_args,omitempty"`
+	NoticeAnomalyScore               int        `jsonapi:"attr,notice_anomaly_score,omitempty"`
+	ParanoiaLevel                    int        `jsonapi:"attr,paranoia_level,omitempty"`
+	PHPInjectionScoreThreshold       int        `jsonapi:"attr,php_injection_score_threshold,omitempty"`
+	RCEScoreThreshold                int        `jsonapi:"attr,rce_score_threshold,omitempty"`
+	RestrictedExtensions             string     `jsonapi:"attr,restricted_extensions,omitempty"`
+	RestrictedHeaders                string     `jsonapi:"attr,restricted_headers,omitempty"`
+	RFIScoreThreshold                int        `jsonapi:"attr,rfi_score_threshold,omitempty"`
+	SessionFixationScoreThreshold    int        `jsonapi:"attr,session_fixation_score_threshold,omitempty"`
+	SQLInjectionScoreThreshold       int        `jsonapi:"attr,sql_injection_score_threshold,omitempty"`
+	TotalArgLength                   int        `jsonapi:"attr,total_arg_length,omitempty"`
+	UpdatedAt                        *time.Time `jsonapi:"attr,updated_at,omitempty,iso8601"`
+	WarningAnomalyScore              int        `jsonapi:"attr,warning_anomaly_score,omitempty"`
+	XSSScoreThreshold                int        `jsonapi:"attr,xss_score_threshold,omitempty"`
 }
 
 // CreateOWASP creates an OWASP settings object for a service firewall object.
@@ -502,9 +503,9 @@ func (c *Client) GetWAFRuleVCL(i *GetWAFRuleVCLInput) (*RuleVCL, error) {
 
 // Ruleset is the information about a firewall object's ruleset.
 type Ruleset struct {
-	ID       string `jsonapi:"primary,ruleset"`
-	VCL      string `jsonapi:"attr,vcl,omitempty"`
-	LastPush string `jsonapi:"attr,last_push,omitempty"`
+	ID       string     `jsonapi:"primary,ruleset"`
+	VCL      string     `jsonapi:"attr,vcl,omitempty"`
+	LastPush *time.Time `jsonapi:"attr,last_push,omitempty,iso8601"`
 }
 
 // GetWAFRuleRuleSetsInput is used as input to the GetWAFRuleRuleSets function.

--- a/fastly/waf.go
+++ b/fastly/waf.go
@@ -217,36 +217,37 @@ func (c *Client) DeleteWAF(i *DeleteWAFInput) error {
 
 // OWASP is the information about an OWASP object.
 type OWASP struct {
-	ID                            string `jsonapi:"primary,owasp"`
-	AllowedHTTPVersions           string `jsonapi:"attr,allowed_http_versions"`
-	AllowedMethods                string `jsonapi:"attr,allowed_methods"`
-	AllowedRequestContentType     string `jsonapi:"attr,allowed_request_content_type"`
-	ArgLength                     int    `jsonapi:"attr,arg_length"`
-	ArgNameLength                 int    `jsonapi:"attr,arg_name_length"`
-	CombinedFileSizes             int    `jsonapi:"attr,combined_file_sizes"`
-	CreatedAt                     string `jsonapi:"attr,created_at"`
-	CriticalAnomalyScore          int    `jsonapi:"attr,critical_anomaly_score"`
-	CRSValidateUTF8Encoding       bool   `jsonapi:"attr,crs_validate_utf8_encoding"`
-	ErrorAnomalyScore             int    `jsonapi:"attr,error_anomaly_score"`
-	HighRiskCountryCodes          string `jsonapi:"attr,high_risk_country_codes"`
-	HTTPViolationScoreThreshold   int    `jsonapi:"attr,http_violation_score_threshold"`
-	InboundAnomalyScoreThreshold  int    `jsonapi:"attr,inbound_anomaly_score_threshold"`
-	LFIScoreThreshold             int    `jsonapi:"attr,lfi_score_threshold"`
-	MaxFileSize                   int    `jsonapi:"attr,max_file_size"`
-	MaxNumArgs                    int    `jsonapi:"attr,max_num_args"`
-	NoticeAnomalyScore            int    `jsonapi:"attr,notice_anomaly_score"`
-	ParanoiaLevel                 int    `jsonapi:"attr,paranoia_level"`
-	PHPInjectionScoreThreshold    int    `jsonapi:"attr,php_injection_score_threshold"`
-	RCEScoreThreshold             int    `jsonapi:"attr,rce_score_threshold"`
-	RestrictedExtensions          string `jsonapi:"attr,restricted_extensions"`
-	RestrictedHeaders             string `jsonapi:"attr,restricted_headers"`
-	RFIScoreThreshold             int    `jsonapi:"attr,rfi_score_threshold"`
-	SessionFixationScoreThreshold int    `jsonapi:"attr,session_fixation_score_threshold"`
-	SQLInjectionScoreThreshold    int    `jsonapi:"attr,sql_injection_score_threshold"`
-	TotalArgLength                int    `jsonapi:"attr,total_arg_length"`
-	UpdatedAt                     string `jsonapi:"attr,updated_at"`
-	WarningAnomalyScore           int    `jsonapi:"attr,warning_anomaly_score"`
-	XSSScoreThreshold             int    `jsonapi:"attr,xss_score_threshold"`
+	ID                               string `jsonapi:"primary,owasp"`
+	AllowedHTTPVersions              string `jsonapi:"attr,allowed_http_versions"`
+	AllowedMethods                   string `jsonapi:"attr,allowed_methods"`
+	AllowedRequestContentType        string `jsonapi:"attr,allowed_request_content_type"`
+	AllowedRequestContentTypeCharset string `jsonapi:"attr,allowed_request_content_type_charset"`
+	ArgLength                        int    `jsonapi:"attr,arg_length"`
+	ArgNameLength                    int    `jsonapi:"attr,arg_name_length"`
+	CombinedFileSizes                int    `jsonapi:"attr,combined_file_sizes"`
+	CreatedAt                        string `jsonapi:"attr,created_at"`
+	CriticalAnomalyScore             int    `jsonapi:"attr,critical_anomaly_score"`
+	CRSValidateUTF8Encoding          bool   `jsonapi:"attr,crs_validate_utf8_encoding"`
+	ErrorAnomalyScore                int    `jsonapi:"attr,error_anomaly_score"`
+	HighRiskCountryCodes             string `jsonapi:"attr,high_risk_country_codes"`
+	HTTPViolationScoreThreshold      int    `jsonapi:"attr,http_violation_score_threshold"`
+	InboundAnomalyScoreThreshold     int    `jsonapi:"attr,inbound_anomaly_score_threshold"`
+	LFIScoreThreshold                int    `jsonapi:"attr,lfi_score_threshold"`
+	MaxFileSize                      int    `jsonapi:"attr,max_file_size"`
+	MaxNumArgs                       int    `jsonapi:"attr,max_num_args"`
+	NoticeAnomalyScore               int    `jsonapi:"attr,notice_anomaly_score"`
+	ParanoiaLevel                    int    `jsonapi:"attr,paranoia_level"`
+	PHPInjectionScoreThreshold       int    `jsonapi:"attr,php_injection_score_threshold"`
+	RCEScoreThreshold                int    `jsonapi:"attr,rce_score_threshold"`
+	RestrictedExtensions             string `jsonapi:"attr,restricted_extensions"`
+	RestrictedHeaders                string `jsonapi:"attr,restricted_headers"`
+	RFIScoreThreshold                int    `jsonapi:"attr,rfi_score_threshold"`
+	SessionFixationScoreThreshold    int    `jsonapi:"attr,session_fixation_score_threshold"`
+	SQLInjectionScoreThreshold       int    `jsonapi:"attr,sql_injection_score_threshold"`
+	TotalArgLength                   int    `jsonapi:"attr,total_arg_length"`
+	UpdatedAt                        string `jsonapi:"attr,updated_at"`
+	WarningAnomalyScore              int    `jsonapi:"attr,warning_anomaly_score"`
+	XSSScoreThreshold                int    `jsonapi:"attr,xss_score_threshold"`
 }
 
 // GetOWASPInput is used as input to the GetOWASP function.
@@ -321,36 +322,37 @@ type UpdateOWASPInput struct {
 	ID      string
 	OWASPID string `jsonapi:"primary,owasp,omitempty"`
 
-	Type                          string `jsonapi:"attr,type"`
-	AllowedHTTPVersions           string `jsonapi:"attr,allowed_http_versions,omitempty"`
-	AllowedMethods                string `jsonapi:"attr,allowed_methods,omitempty"`
-	AllowedRequestContentType     string `jsonapi:"attr,allowed_request_content_type,omitempty"`
-	ArgLength                     int    `jsonapi:"attr,arg_length,omitempty"`
-	ArgNameLength                 int    `jsonapi:"attr,arg_name_length,omitempty"`
-	CombinedFileSizes             int    `jsonapi:"attr,combined_file_sizes,omitempty"`
-	CreatedAt                     string `jsonapi:"attr,created_at,omitempty"`
-	CriticalAnomalyScore          int    `jsonapi:"attr,critical_anomaly_score,omitempty"`
-	CRSValidateUTF8Encoding       bool   `jsonapi:"attr,crs_validate_utf8_encoding,omitempty"`
-	ErrorAnomalyScore             int    `jsonapi:"attr,error_anomaly_score,omitempty"`
-	HighRiskCountryCodes          string `jsonapi:"attr,high_risk_country_codes,omitempty"`
-	HTTPViolationScoreThreshold   int    `jsonapi:"attr,http_violation_score_threshold,omitempty"`
-	InboundAnomalyScoreThreshold  int    `jsonapi:"attr,inbound_anomaly_score_threshold,omitempty"`
-	LFIScoreThreshold             int    `jsonapi:"attr,lfi_score_threshold,omitempty"`
-	MaxFileSize                   int    `jsonapi:"attr,max_file_size,omitempty"`
-	MaxNumArgs                    int    `jsonapi:"attr,max_num_args,omitempty"`
-	NoticeAnomalyScore            int    `jsonapi:"attr,notice_anomaly_score,omitempty"`
-	ParanoiaLevel                 int    `jsonapi:"attr,paranoia_level,omitempty"`
-	PHPInjectionScoreThreshold    int    `jsonapi:"attr,php_injection_score_threshold,omitempty"`
-	RCEScoreThreshold             int    `jsonapi:"attr,rce_score_threshold,omitempty"`
-	RestrictedExtensions          string `jsonapi:"attr,restricted_extensions,omitempty"`
-	RestrictedHeaders             string `jsonapi:"attr,restricted_headers,omitempty"`
-	RFIScoreThreshold             int    `jsonapi:"attr,rfi_score_threshold,omitempty"`
-	SessionFixationScoreThreshold int    `jsonapi:"attr,session_fixation_score_threshold,omitempty"`
-	SQLInjectionScoreThreshold    int    `jsonapi:"attr,sql_injection_score_threshold,omitempty"`
-	TotalArgLength                int    `jsonapi:"attr,total_arg_length,omitempty"`
-	UpdatedAt                     string `jsonapi:"attr,updated_at,omitempty"`
-	WarningAnomalyScore           int    `jsonapi:"attr,warning_anomaly_score,omitempty"`
-	XSSScoreThreshold             int    `jsonapi:"attr,xss_score_threshold,omitempty"`
+	Type                             string `jsonapi:"attr,type"`
+	AllowedHTTPVersions              string `jsonapi:"attr,allowed_http_versions,omitempty"`
+	AllowedMethods                   string `jsonapi:"attr,allowed_methods,omitempty"`
+	AllowedRequestContentType        string `jsonapi:"attr,allowed_request_content_type,omitempty"`
+	AllowedRequestContentTypeCharset string `jsonapi:"attr,allowed_request_content_type_charset,omitempty"`
+	ArgLength                        int    `jsonapi:"attr,arg_length,omitempty"`
+	ArgNameLength                    int    `jsonapi:"attr,arg_name_length,omitempty"`
+	CombinedFileSizes                int    `jsonapi:"attr,combined_file_sizes,omitempty"`
+	CreatedAt                        string `jsonapi:"attr,created_at,omitempty"`
+	CriticalAnomalyScore             int    `jsonapi:"attr,critical_anomaly_score,omitempty"`
+	CRSValidateUTF8Encoding          bool   `jsonapi:"attr,crs_validate_utf8_encoding,omitempty"`
+	ErrorAnomalyScore                int    `jsonapi:"attr,error_anomaly_score,omitempty"`
+	HighRiskCountryCodes             string `jsonapi:"attr,high_risk_country_codes,omitempty"`
+	HTTPViolationScoreThreshold      int    `jsonapi:"attr,http_violation_score_threshold,omitempty"`
+	InboundAnomalyScoreThreshold     int    `jsonapi:"attr,inbound_anomaly_score_threshold,omitempty"`
+	LFIScoreThreshold                int    `jsonapi:"attr,lfi_score_threshold,omitempty"`
+	MaxFileSize                      int    `jsonapi:"attr,max_file_size,omitempty"`
+	MaxNumArgs                       int    `jsonapi:"attr,max_num_args,omitempty"`
+	NoticeAnomalyScore               int    `jsonapi:"attr,notice_anomaly_score,omitempty"`
+	ParanoiaLevel                    int    `jsonapi:"attr,paranoia_level,omitempty"`
+	PHPInjectionScoreThreshold       int    `jsonapi:"attr,php_injection_score_threshold,omitempty"`
+	RCEScoreThreshold                int    `jsonapi:"attr,rce_score_threshold,omitempty"`
+	RestrictedExtensions             string `jsonapi:"attr,restricted_extensions,omitempty"`
+	RestrictedHeaders                string `jsonapi:"attr,restricted_headers,omitempty"`
+	RFIScoreThreshold                int    `jsonapi:"attr,rfi_score_threshold,omitempty"`
+	SessionFixationScoreThreshold    int    `jsonapi:"attr,session_fixation_score_threshold,omitempty"`
+	SQLInjectionScoreThreshold       int    `jsonapi:"attr,sql_injection_score_threshold,omitempty"`
+	TotalArgLength                   int    `jsonapi:"attr,total_arg_length,omitempty"`
+	UpdatedAt                        string `jsonapi:"attr,updated_at,omitempty"`
+	WarningAnomalyScore              int    `jsonapi:"attr,warning_anomaly_score,omitempty"`
+	XSSScoreThreshold                int    `jsonapi:"attr,xss_score_threshold,omitempty"`
 }
 
 // CreateOWASP creates an OWASP settings object for a service firewall object.

--- a/fastly/waf_test.go
+++ b/fastly/waf_test.go
@@ -17,9 +17,8 @@ func TestClient_WAFs(t *testing.T) {
 
 	// Enable logging on the service - we cannot create wafs without logging
 	// enabled
-	var s *Syslog
 	record(t, "wafs/logging/create", func(c *Client) {
-		s, err = c.CreateSyslog(&CreateSyslogInput{
+		_, err = c.CreateSyslog(&CreateSyslogInput{
 			Service:       testServiceID,
 			Version:       tv.Number,
 			Name:          "test-syslog",


### PR DESCRIPTION
This adds support for allowed_request_content_type_charset, addresses #54, fixes the tests and changes the go version to 1.10 and 1.11.

The former will be documented this week but it's already visible in the API response.