### PR TITLE
Adding support for snippet update

### DIFF
--- a/fastly/fixtures/vcl_snippets/create.yaml
+++ b/fastly/fixtures/vcl_snippets/create.yaml
@@ -3,12 +3,12 @@ version: 1
 rwmutex: {}
 interactions:
 - request:
-    body: ServiceID=7i6HN3TK9wS159v2gPAZ8A&Version=688&content=%0A%09%23+testing+EdgeACL2+and+EdgeDictionary2%0A%09+declare+local+var.number2+STRING%3B%0A%09+set+var.number2+%3D+table.lookup%28demoDICTtest%2C+client.as.number%29%3B%0A%0A%09+if+%28var.number2+%3D%3D+%22true%22%29+%7B%0A%09+++set+req.http.securityruleid+%3D+%22num2-block%22%3B%0A%09+error+403+%22Access+Denied%22%3B%0A%09++%7D%0A++++&dynamic=0&name=testsnip0&priority=100&type=recv
+    body: Service=7i6HN3TK9wS159v2gPAZ8A&Version=3&content=%0A%09%23+testing+EdgeACL2+and+EdgeDictionary2%0A%09+declare+local+var.number2+STRING%3B%0A%09+set+var.number2+%3D+table.lookup%28demoDICTtest%2C+client.as.number%29%3B%0A%0A%09+if+%28var.number2+%3D%3D+%22true%22%29+%7B%0A%09+++set+req.http.securityruleid+%3D+%22num2-block%22%3B%0A%09+error+403+%22Access+Denied%22%3B%0A%09++%7D%0A++++&dynamic=0&name=testsnip0&priority=100&type=recv
     form:
-      ServiceID:
+      Service:
       - 7i6HN3TK9wS159v2gPAZ8A
       Version:
-      - "688"
+      - "3"
       content:
       - "\n\t# testing EdgeACL2 and EdgeDictionary2\n\t declare local var.number2
         STRING;\n\t set var.number2 = table.lookup(demoDICTtest, client.as.number);\n\n\t
@@ -28,29 +28,32 @@ interactions:
       Fastly-Key:
       - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/sethvargo/go-fastly; go1.10.3)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/688/snippet
+      - FastlyGo/0.4.3.dev (+github.com/sethvargo/go-fastly; go1.11.2)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/3/snippet
     method: POST
   response:
     body: '{"content":"\n\t# testing EdgeACL2 and EdgeDictionary2\n\t declare local
       var.number2 STRING;\n\t set var.number2 = table.lookup(demoDICTtest, client.as.number);\n\n\t
       if (var.number2 == \"true\") {\n\t   set req.http.securityruleid = \"num2-block\";\n\t
-      error 403 \"Access Denied\";\n\t  }\n    ","dynamic":0,"name":"testsnip0","priority":"100","type":"recv","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":"688","deleted_at":null,"created_at":"2018-08-15T19:24:56Z","updated_at":"2018-08-15T19:24:56Z","id":"6xU4LMOPEAhapB8ZOa0QqG"}'
+      error 403 \"Access Denied\";\n\t  }\n    ","dynamic":0,"name":"testsnip0","priority":"100","type":"recv","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":"3","deleted_at":null,"created_at":"2019-04-12T14:04:36Z","updated_at":"2019-04-12T14:04:36Z","id":"4uUKgsjWz7hmPCLDTIkj8j"}'
     headers:
       Accept-Ranges:
+      - bytes
       - bytes
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
       Date:
-      - Wed, 15 Aug 2018 19:24:56 GMT
+      - Fri, 12 Apr 2019 14:04:36 GMT
       Fastly-Ratelimit-Remaining:
-      - "999"
+      - "993"
       Fastly-Ratelimit-Reset:
-      - "1534363200"
+      - "1555081200"
       Status:
       - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
       Vary:
       - Accept-Encoding
       Via:
@@ -61,8 +64,8 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - app-slwdc9051-SL, cache-mdw17356-MDW
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-fra19162-FRA
       X-Timer:
-      - S1534361096.358762,VS0,VE222
+      - S1555077876.679397,VS0,VE542
     status: 200 OK
     code: 200

--- a/fastly/fixtures/vcl_snippets/create_dyn.yaml
+++ b/fastly/fixtures/vcl_snippets/create_dyn.yaml
@@ -3,12 +3,12 @@ version: 1
 rwmutex: {}
 interactions:
 - request:
-    body: ServiceID=7i6HN3TK9wS159v2gPAZ8A&Version=688&content=%0A%09+%23+testing+EdgeACL6+and+EdgeDictionary6%0A%09++declare+local+var.number6+STRING%3B%0A%09++set+var.number6+%3D+table.lookup%28demoDICTtest%2C+client.as.number%29%3B%0A%0A%09++if+%28var.number6+%3D%3D+%22true%22%29+%7B%0A%09++++set+req.http.securityruleid+%3D+%22num6-block%22%3B%0A%09+error+403+%22Access+Denied%22%3B%0A%09++%7D%0A%09&dynamic=1&name=testsnip5&priority=100&type=recv
+    body: Service=7i6HN3TK9wS159v2gPAZ8A&Version=3&content=%0A%09+%23+testing+EdgeACL6+and+EdgeDictionary6%0A%09++declare+local+var.number6+STRING%3B%0A%09++set+var.number6+%3D+table.lookup%28demoDICTtest%2C+client.as.number%29%3B%0A%0A%09++if+%28var.number6+%3D%3D+%22true%22%29+%7B%0A%09++++set+req.http.securityruleid+%3D+%22num6-block%22%3B%0A%09+error+403+%22Access+Denied%22%3B%0A%09++%7D%0A%09&dynamic=1&name=testsnip6&priority=100&type=recv
     form:
-      ServiceID:
+      Service:
       - 7i6HN3TK9wS159v2gPAZ8A
       Version:
-      - "688"
+      - "3"
       content:
       - "\n\t # testing EdgeACL6 and EdgeDictionary6\n\t  declare local var.number6
         STRING;\n\t  set var.number6 = table.lookup(demoDICTtest, client.as.number);\n\n\t
@@ -28,26 +28,29 @@ interactions:
       Fastly-Key:
       - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/sethvargo/go-fastly; go1.10.3)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/688/snippet
+      - FastlyGo/0.4.3.dev (+github.com/sethvargo/go-fastly; go1.11.2)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/3/snippet
     method: POST
   response:
-    body: '{"content":null,"dynamic":1,"name":"testsnip5","priority":"100","type":"recv","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":"688","deleted_at":null,"created_at":"2018-08-15T17:12:48Z","updated_at":"2018-08-15T17:12:48Z","id":"dynsnipxxxxxxxxxxxxxid"}'
+    body: '{"content":null,"dynamic":1,"name":"testsnip5","priority":"100","type":"recv","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":"3","deleted_at":null,"created_at":"2019-04-12T14:04:36Z","updated_at":"2019-04-12T14:04:36Z","id":"5U9t9k5YbRHRmq5wmwIl2Z"}'
     headers:
       Accept-Ranges:
+      - bytes
       - bytes
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
       Date:
-      - Wed, 15 Aug 2018 17:12:48 GMT
+      - Fri, 12 Apr 2019 14:04:36 GMT
       Fastly-Ratelimit-Remaining:
-      - "999"
+      - "992"
       Fastly-Ratelimit-Reset:
-      - "1534356000"
+      - "1555081200"
       Status:
       - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
       Vary:
       - Accept-Encoding
       Via:
@@ -58,8 +61,8 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - app-slwdc9051-SL, cache-mdw17329-MDW
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-fra19162-FRA
       X-Timer:
-      - S1534353169.593643,VS0,VE255
+      - S1555077876.235585,VS0,VE229
     status: 200 OK
     code: 200

--- a/fastly/fixtures/vcl_snippets/delete.yaml
+++ b/fastly/fixtures/vcl_snippets/delete.yaml
@@ -4,39 +4,34 @@ rwmutex: {}
 interactions:
 - request:
     body: ""
-    form:
-      ServiceID:
-      - 7i6HN3TK9wS159v2gPAZ8A
-      Version:
-      - "688"
-      Snippet:
-      - testsnip5
+    form: {}
     headers:
-      Content-Type:
-      - application/x-www-form-urlencoded
       Fastly-Key:
       - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/sethvargo/go-fastly; go1.10.3)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/688/snippet/testsnip5
+      - FastlyGo/0.4.3.dev (+github.com/sethvargo/go-fastly; go1.11.2)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/3/snippet/testsnip5
     method: DELETE
   response:
     body: '{"status":"ok"}'
     headers:
       Accept-Ranges:
       - bytes
+      - bytes
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
       Date:
-      - Thu, 20 Jul 2017 01:15:11 GMT
+      - Fri, 12 Apr 2019 14:04:37 GMT
       Fastly-Ratelimit-Remaining:
-      - "892"
+      - "990"
       Fastly-Ratelimit-Reset:
-      - "1500516000"
+      - "1555081200"
       Status:
       - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
       Vary:
       - Accept-Encoding
       Via:
@@ -47,8 +42,8 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - app-slwdc9051-SL, cache-dca17722-DCA
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-fra19162-FRA
       X-Timer:
-      - S1500513311.712694,VS0,VE456
+      - S1555077877.075968,VS0,VE322
     status: 200 OK
     code: 200

--- a/fastly/fixtures/vcl_snippets/get.yaml
+++ b/fastly/fixtures/vcl_snippets/get.yaml
@@ -9,17 +9,18 @@ interactions:
       Fastly-Key:
       - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/sethvargo/go-fastly; go1.10.3)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/688/snippet/testsnip0
+      - FastlyGo/0.4.3.dev (+github.com/sethvargo/go-fastly; go1.11.2)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/3/snippet/testsnip0
     method: GET
   response:
-    body: '{"priority":"100","version":"688","dynamic":"0","name":"testsnip0","content":"\n\t#
+    body: '{"priority":"100","version":"3","dynamic":"0","name":"testsnip0","content":"\n\t#
       testing EdgeACL2 and EdgeDictionary2\n\t declare local var.number2 STRING;\n\t
       set var.number2 = table.lookup(demoDICTtest, client.as.number);\n\n\t if (var.number2
       == \"true\") {\n\t   set req.http.securityruleid = \"num2-block\";\n\t error
-      403 \"Access Denied\";\n\t  }\n    ","deleted_at":null,"service_id":"7i6HN3TK9wS159v2gPAZ8A","created_at":"2018-08-15T19:24:56Z","updated_at":"2018-08-15T19:24:56Z","id":"6xU4LMOPEAhapB8ZOa0QqG","type":"recv"}'
+      403 \"Access Denied\";\n\t  }\n    ","deleted_at":null,"service_id":"7i6HN3TK9wS159v2gPAZ8A","created_at":"2019-04-12T14:04:36Z","updated_at":"2019-04-12T14:04:36Z","id":"4uUKgsjWz7hmPCLDTIkj8j","type":"recv"}'
     headers:
       Accept-Ranges:
+      - bytes
       - bytes
       - bytes
       Age:
@@ -30,9 +31,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 15 Aug 2018 20:06:22 GMT
+      - Fri, 12 Apr 2019 14:04:38 GMT
       Status:
       - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
       Vary:
       - Accept-Encoding
       Via:
@@ -43,8 +46,8 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - app-slwdc9051-SL, cache-mdw17351-MDW
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-fra19162-FRA
       X-Timer:
-      - S1534363583.811321,VS0,VE123
+      - S1555077878.082045,VS0,VE541
     status: 200 OK
     code: 200

--- a/fastly/fixtures/vcl_snippets/get_dynamic.yaml
+++ b/fastly/fixtures/vcl_snippets/get_dynamic.yaml
@@ -9,17 +9,18 @@ interactions:
       Fastly-Key:
       - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/sethvargo/go-fastly; go1.10.3)
+      - FastlyGo/0.4.3.dev (+github.com/sethvargo/go-fastly; go1.11.2)
     url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/snippet/dynsnipxxxxxxxxxxxxxid
     method: GET
   response:
-    body: '{"snippet_id":"dynsnipxxxxxxxxxxxxxid","created_at":"2018-08-15T17:12:48Z","content":"\n\t
+    body: '{"snippet_id":"dynsnipxxxxxxxxxxxxxid","created_at":"2019-03-11T17:38:56Z","content":"\n\t
       # testing EdgeACL5 and EdgeDictionary5\n\t declare local var.number5 STRING;\n\t
       set var.number5 = table.lookup(demoDICTtest, client.as.number);\n\n\t if (var.number5
       == \"true\") {\n\t set req.http.securityruleid = \"num5-block\";\n\t error 403
-      \"Access Denied\";\n\t  }\n    ","service_id":"7i6HN3TK9wS159v2gPAZ8A","updated_at":"2018-08-15T17:32:25Z"}'
+      \"Access Denied\";\n\t  }\n    ","service_id":"7i6HN3TK9wS159v2gPAZ8A","updated_at":"2019-03-11T17:47:23Z"}'
     headers:
       Accept-Ranges:
+      - bytes
       - bytes
       - bytes
       Age:
@@ -30,9 +31,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 15 Aug 2018 18:32:57 GMT
+      - Fri, 12 Apr 2019 14:04:38 GMT
       Status:
       - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
       Vary:
       - Accept-Encoding
       Via:
@@ -43,8 +46,8 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - app-slwdc9051-SL, cache-mdw17345-MDW
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-fra19162-FRA
       X-Timer:
-      - S1534357978.786430,VS0,VE113
+      - S1555077877.494234,VS0,VE543
     status: 200 OK
     code: 200

--- a/fastly/fixtures/vcl_snippets/list.yaml
+++ b/fastly/fixtures/vcl_snippets/list.yaml
@@ -9,17 +9,18 @@ interactions:
       Fastly-Key:
       - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/sethvargo/go-fastly; go1.10.3)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/688/snippet
+      - FastlyGo/0.4.3.dev (+github.com/sethvargo/go-fastly; go1.11.2)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/3/snippet
     method: GET
   response:
-    body: '[{"priority":"100","version":"688","dynamic":"0","name":"testsnip0","content":"\n\t#
-      testing EdgeACL2 and EdgeDictionary2\n\t declare local var.number2 STRING;\n\t
-      set var.number2 = table.lookup(demoDICTtest, client.as.number);\n\n\t if (var.number2
-      == \"true\") {\n\t   set req.http.securityruleid = \"num2-block\";\n\t error
-      403 \"Access Denied\";\n\t  }\n    ","deleted_at":null,"service_id":"7i6HN3TK9wS159v2gPAZ8A","created_at":"2018-08-15T19:24:56Z","updated_at":"2018-08-15T19:24:56Z","id":"6xU4LMOPEAhapB8ZOa0QqG","type":"recv"},{"priority":"100","version":"688","dynamic":"1","name":"testsnip5","content":null,"deleted_at":null,"service_id":"7i6HN3TK9wS159v2gPAZ8A","created_at":"2018-08-15T17:12:48Z","updated_at":"2018-08-15T17:12:48Z","id":"3O8UA20ydNh4hSBhqZyiqU","type":"recv"}]'
+    body: '[{"priority":"50","version":"3","dynamic":"0","name":"newTestSnippetName","content":"\n\t
+      # testing EdgeACL5 and EdgeDictionary5\n\t declare local var.number5 STRING;\n\t
+      set var.number5 = table.lookup(demoDICTtest, client.as.number);\n\n\t if (var.number5
+      == \"true\") {\n\t set req.http.securityruleid = \"num5-block\";\n\t error 403
+      \"Access Denied\";\n\t  }\n    ","deleted_at":null,"service_id":"7i6HN3TK9wS159v2gPAZ8A","created_at":"2019-04-12T14:04:36Z","updated_at":"2019-04-12T14:04:38Z","id":"4uUKgsjWz7hmPCLDTIkj8j","type":"none"}]'
     headers:
       Accept-Ranges:
+      - bytes
       - bytes
       - bytes
       Age:
@@ -30,9 +31,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 15 Aug 2018 19:44:37 GMT
+      - Fri, 12 Apr 2019 14:04:39 GMT
       Status:
       - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
       Vary:
       - Accept-Encoding
       Via:
@@ -43,8 +46,8 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - app-slwdc9051-SL, cache-mdw17370-MDW
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-fra19162-FRA
       X-Timer:
-      - S1534362277.884002,VS0,VE197
+      - S1555077879.008422,VS0,VE548
     status: 200 OK
     code: 200

--- a/fastly/fixtures/vcl_snippets/update_dyn.yaml
+++ b/fastly/fixtures/vcl_snippets/update_dyn.yaml
@@ -3,27 +3,17 @@ version: 1
 rwmutex: {}
 interactions:
 - request:
-    body: Name=testsnip0&Service=7i6HN3TK9wS159v2gPAZ8A&Version=3&content=%0A%09+%23+testing+EdgeACL5+and+EdgeDictionary5%0A%09+declare+local+var.number5+STRING%3B%0A%09+set+var.number5+%3D+table.lookup%28demoDICTtest%2C+client.as.number%29%3B%0A%0A%09+if+%28var.number5+%3D%3D+%22true%22%29+%7B%0A%09+set+req.http.securityruleid+%3D+%22num5-block%22%3B%0A%09+error+403+%22Access+Denied%22%3B%0A%09++%7D%0A++++&dynamic=0&name=newTestSnippetName&priority=50&type=none
+    body: ID=6Zeo3Ejv56qqhY6PVHfCxZ&Service=7i6HN3TK9wS159v2gPAZ8A&content=%0A%09+%23+testing+EdgeACL5+and+EdgeDictionary5%0A%09+declare+local+var.number5+STRING%3B%0A%09+set+var.number5+%3D+table.lookup%28demoDICTtest%2C+client.as.number%29%3B%0A%0A%09+if+%28var.number5+%3D%3D+%22true%22%29+%7B%0A%09+set+req.http.securityruleid+%3D+%22num5-block%22%3B%0A%09+error+403+%22Access+Denied%22%3B%0A%09++%7D%0A++++
     form:
-      Name:
-      - testsnip0
+      ID:
+      - dynsnipxxxxxxxxxxxxxid
       Service:
       - 7i6HN3TK9wS159v2gPAZ8A
-      Version:
-      - "3"
       content:
       - "\n\t # testing EdgeACL5 and EdgeDictionary5\n\t declare local var.number5
         STRING;\n\t set var.number5 = table.lookup(demoDICTtest, client.as.number);\n\n\t
         if (var.number5 == \"true\") {\n\t set req.http.securityruleid = \"num5-block\";\n\t
         error 403 \"Access Denied\";\n\t  }\n    "
-      dynamic:
-      - "0"
-      name:
-      - newTestSnippetName
-      priority:
-      - "50"
-      type:
-      - none
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
@@ -31,14 +21,14 @@ interactions:
       - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
       - FastlyGo/0.4.3.dev (+github.com/sethvargo/go-fastly; go1.11.2)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/3/snippet/testsnip0
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/snippet/dynsnipxxxxxxxxxxxxxid
     method: PUT
   response:
-    body: '{"priority":"50","version":"3","dynamic":"0","name":"newTestSnippetName","content":"\n\t
+    body: '{"snippet_id":"dynsnipxxxxxxxxxxxxxid","created_at":"2019-03-11T17:38:56Z","content":"\n\t
       # testing EdgeACL5 and EdgeDictionary5\n\t declare local var.number5 STRING;\n\t
       set var.number5 = table.lookup(demoDICTtest, client.as.number);\n\n\t if (var.number5
       == \"true\") {\n\t set req.http.securityruleid = \"num5-block\";\n\t error 403
-      \"Access Denied\";\n\t  }\n    ","deleted_at":null,"service_id":"7i6HN3TK9wS159v2gPAZ8A","created_at":"2019-04-12T14:04:36Z","updated_at":"2019-04-12T14:04:36Z","id":"snipxxxxxxxxxxxxxxxxid","type":"none"}'
+      \"Access Denied\";\n\t  }\n    ","service_id":"7i6HN3TK9wS159v2gPAZ8A","updated_at":"2019-03-11T17:47:23Z"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -48,9 +38,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 12 Apr 2019 14:04:38 GMT
+      - Fri, 12 Apr 2019 14:04:36 GMT
       Fastly-Ratelimit-Remaining:
-      - "989"
+      - "991"
       Fastly-Ratelimit-Reset:
       - "1555081200"
       Status:
@@ -69,6 +59,6 @@ interactions:
       X-Served-By:
       - cache-control-slwdc9036-CONTROL-SLWDC, cache-fra19162-FRA
       X-Timer:
-      - S1555077879.641794,VS0,VE201
+      - S1555077876.479598,VS0,VE494
     status: 200 OK
     code: 200

--- a/fastly/vcl_snippets.go
+++ b/fastly/vcl_snippets.go
@@ -126,6 +126,63 @@ func (c *Client) CreateSnippet(i *CreateSnippetInput) (*Snippet, error) {
 	return snippet, err
 }
 
+// UpdateSnippetInput is the input for UpdateSnippet
+type UpdateSnippetInput struct {
+	// Service is the ID of the Service to add the snippet to.
+	Service string
+
+	// Version is the editable version of the service
+	Version int
+
+	Name string
+
+	// Name is the name for the snippet.
+	NewName string `form:"name"`
+
+	// Priority determines the ordering for multiple snippets. Lower numbers execute first.
+	Priority int `form:"priority"`
+
+	// Dynamic sets the snippet version to regular (0) or dynamic (1).
+	Dynamic int `form:"dynamic"`
+
+	// Content is the VCL code that specifies exactly what the snippet does.
+	Content string `form:"content"`
+
+	// Type is the location in generated VCL where the snippet should be placed.
+	Type SnippetType `form:"type"`
+}
+
+// UpdateSnippet updates a snippet on a unlocked version
+func (c *Client) UpdateSnippet(i *UpdateSnippetInput) (*Snippet, error) {
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
+
+	if i.Version == 0 {
+		return nil, ErrMissingVersion
+	}
+
+	if i.Name == "" {
+		return nil, ErrMissingName
+	}
+
+	if i.Dynamic == 0 && i.Content == "" {
+		return nil, ErrMissingContent
+	}
+
+	path := fmt.Sprintf("/service/%s/version/%d/snippet/%s", i.Service, i.Version, i.Name)
+	resp, err := c.PutForm(path, i, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var snippet *Snippet
+	if err := decodeJSON(&snippet, resp.Body); err != nil {
+		return nil, err
+	}
+	return snippet, err
+}
+
 // DynamicSnippet is the object returned when updating or retrieving a Dynamic Snippet
 type DynamicSnippet struct {
 	// Service is the ID of the Service to add the snippet to.

--- a/fastly/vcl_snippets_test.go
+++ b/fastly/vcl_snippets_test.go
@@ -104,6 +104,34 @@ func Test_Snippets(t *testing.T) {
 	}
 
 	// Update
+	var us *Snippet
+	record(t, "vcl_snippets/update", func(c *Client) {
+		us, err = c.UpdateSnippet(&UpdateSnippetInput{
+			Service:  testServiceID,
+			Name:     testSnippetName,
+			NewName:  "newTestSnippetName",
+			Content:  updatedDynContent,
+			Dynamic:  1,
+			Type:     "none",
+			Priority: 50,
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if us.Name != "newTestSnippetName" {
+		t.Errorf("bad updated name")
+	}
+	if us.Priority != 50 {
+		t.Errorf("bad priority: %d", us.Priority)
+	}
+
+	if us.Content != updatedDynContent {
+		t.Errorf("bad content: %q", us.Content)
+	}
+
+	// Update Dynamic
 	var uds *DynamicSnippet
 	record(t, "vcl_snippets/update", func(c *Client) {
 		uds, err = c.UpdateDynamicSnippet(&UpdateDynamicSnippetInput{

--- a/fastly/vcl_snippets_test.go
+++ b/fastly/vcl_snippets_test.go
@@ -114,6 +114,7 @@ func Test_Snippets(t *testing.T) {
 			Dynamic:  1,
 			Type:     "none",
 			Priority: 50,
+			Version:  tv,
 		})
 	})
 	if err != nil {
@@ -129,6 +130,10 @@ func Test_Snippets(t *testing.T) {
 
 	if us.Content != updatedDynContent {
 		t.Errorf("bad content: %q", us.Content)
+	}
+
+	if us.Type != "none" {
+		t.Errorf("bad type: %s", us.Type)
 	}
 
 	// Update Dynamic

--- a/fastly/vcl_snippets_test.go
+++ b/fastly/vcl_snippets_test.go
@@ -7,7 +7,7 @@ func Test_Snippets(t *testing.T) {
 
 	var err error
 	const (
-		tv                 = 688
+		tv                 = 3
 		testDynSnippetID   = "dynsnipxxxxxxxxxxxxxid"
 		testSnippetID      = "snipxxxxxxxxxxxxxxxxid"
 		testDynSnippetName = "testsnip5"
@@ -103,42 +103,9 @@ func Test_Snippets(t *testing.T) {
 		t.Errorf("bad type: %q", cds.Type)
 	}
 
-	// Update
-	var us *Snippet
-	record(t, "vcl_snippets/update", func(c *Client) {
-		us, err = c.UpdateSnippet(&UpdateSnippetInput{
-			Service:  testServiceID,
-			Name:     testSnippetName,
-			NewName:  "newTestSnippetName",
-			Content:  updatedDynContent,
-			Dynamic:  1,
-			Type:     "none",
-			Priority: 50,
-			Version:  tv,
-		})
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if us.Name != "newTestSnippetName" {
-		t.Errorf("bad updated name")
-	}
-	if us.Priority != 50 {
-		t.Errorf("bad priority: %d", us.Priority)
-	}
-
-	if us.Content != updatedDynContent {
-		t.Errorf("bad content: %q", us.Content)
-	}
-
-	if us.Type != "none" {
-		t.Errorf("bad type: %s", us.Type)
-	}
-
 	// Update Dynamic
 	var uds *DynamicSnippet
-	record(t, "vcl_snippets/update", func(c *Client) {
+	record(t, "vcl_snippets/update_dyn", func(c *Client) {
 		uds, err = c.UpdateDynamicSnippet(&UpdateDynamicSnippetInput{
 			Service: testServiceID,
 			ID:      testDynSnippetID,
@@ -205,6 +172,39 @@ func Test_Snippets(t *testing.T) {
 	}
 	if gs.Content != content {
 		t.Errorf("bad content: %q", gs.Content)
+	}
+
+	// Update
+	var us *Snippet
+	record(t, "vcl_snippets/update", func(c *Client) {
+		us, err = c.UpdateSnippet(&UpdateSnippetInput{
+			Service:  testServiceID,
+			Name:     testSnippetName,
+			NewName:  "newTestSnippetName",
+			Content:  updatedDynContent,
+			Dynamic:  0,
+			Type:     "none",
+			Priority: 50,
+			Version:  tv,
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if us.Name != "newTestSnippetName" {
+		t.Errorf("bad updated name")
+	}
+	if us.Priority != 50 {
+		t.Errorf("bad priority: %d", us.Priority)
+	}
+
+	if us.Content != updatedDynContent {
+		t.Errorf("bad content: %q", us.Content)
+	}
+
+	if us.Type != "none" {
+		t.Errorf("bad type: %s", us.Type)
 	}
 
 	// ListSnippets


### PR DESCRIPTION
Hi Currently only dynamic snippets support, this is an effort to add update capability for normal snippets and cover https://docs.fastly.com/api/config#snippet_e74c500822f252e309a03e0d2727d7b3

I added unittests, but since all the tests were run with a particular service id, I didn't know the policy of how new contributions are accepted. I would be happy if you guide me on this.